### PR TITLE
Add initial dummy example code to illustrate draft spec.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "examples/open-simulation-interface"]
+	path = examples/open-simulation-interface
+	url = https://github.com/OpenSimulationInterface/open-simulation-interface.git
+	branch = feature/initial-build-system

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,10 @@
+The source code and documentation in this repository is distributed
+under the terms of the Mozilla Public License, v. 2.0, attached below,
+unless stated otherwise.
+
+The files fmi2Functions.h, fmi2FunctionTypes.h and fmi2TypesPlatform.h
+are distributed under the terms indicated in their header comments.
+
 Mozilla Public License Version 2.0
 ==================================
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The following basic conventions apply:
 
 ## Examples
 
-An example dummy sensor model implementation is provided as a seperate
+An example dummy sensor model implementation is provided in the
+OSMPDummySensor sub-directory of the examples directory of this
 repository.  Below you can find an example modelDescription.xml
 file that would satisfy the requirements of this document for a sensor
 model FMU with one input and output and no additional features:
@@ -216,13 +217,13 @@ model FMU with one input and output and no additional features:
     <ScalarVariable name="OSMPSensorDataIn.size" valueReference="2" causality="input" variability="discrete">
       <Integer start="0"/>
     </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.base.lo" valueReference="3" causality="output" variability="discrete">
+    <ScalarVariable name="OSMPSensorDataOut.base.lo" valueReference="3" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
     </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.base.hi" valueReference="4" causality="output" variability="discrete">
+    <ScalarVariable name="OSMPSensorDataOut.base.hi" valueReference="4" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
     </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.size" valueReference="5" causality="output" variability="discrete">
+    <ScalarVariable name="OSMPSensorDataOut.size" valueReference="5" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
     </ScalarVariable>
   </ModelVariables>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.7)
+add_subdirectory( open-simulation-interface )
+include_directories( includes )
+add_subdirectory( OSMPDummySensor )

--- a/examples/OSMPDummySensor/CMakeLists.txt
+++ b/examples/OSMPDummySensor/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.7)
+project(OSMPDummySensor)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+find_package(Protobuf 2.6.1 REQUIRED)
+add_library(OSMPDummySensor SHARED OSMPDummySensor.cpp)
+set_target_properties(OSMPDummySensor PROPERTIES PREFIX "")
+include_directories(${OSI_PROTOBUF_INCLUDE_PATH})
+target_link_libraries(OSMPDummySensor open_simulation_interface_pic)
+if(WIN32)
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(FMI_BINARIES_PLATFORM "win64")
+	else()
+		set(FMI_BINARIES_PLATFORM "win32")
+	endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(FMI_BINARIES_PLATFORM "linux64")
+	else()
+		set(FMI_BINARIES_PLATFORM "linux32")
+	endif()
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(FMI_BINARIES_PLATFORM "darwin64")
+	else()
+		set(FMI_BINARIES_PLATFORM "darwin32")
+	endif()
+endif()
+add_custom_command(TARGET OSMPDummySensor
+	POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
+	COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
+	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OSMPDummySensor> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
+	COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "../OSMPDummySensor.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/examples/OSMPDummySensor/OSMPDummySensor.cpp
+++ b/examples/OSMPDummySensor/OSMPDummySensor.cpp
@@ -1,0 +1,642 @@
+/*
+ * PMSF FMU Framework for FMI 2.0 Co-Simulation FMUs
+ *
+ * (C) 2016 -- 2017 PMSF IT Consulting Pierre R. Mai
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "OSMPDummySensor.h"
+
+/*
+ * Debug Breaks
+ *
+ * If you define DEBUGBREAKS the DLL will automatically break
+ * into an attached Debugger on all major computation functions.
+ * Note that the DLL is likely to break all environments if no
+ * Debugger is actually attached when the breaks are triggered.
+ */
+#ifndef NDEBUG
+#ifdef DEBUGBREAKS
+#include <intrin.h>
+#define DEBUGBREAK() __debugbreak()
+#else
+#define DEBUGBREAK()
+#endif
+#else
+#define DEBUGBREAK()
+#endif
+
+#include <iostream>
+#include <string>
+#include <algorithm>
+#include <cstdint>
+
+using namespace std;
+
+#ifdef PRIVATE_LOG_PATH
+ofstream COSMPDummySensor::private_log_file;
+#endif
+
+/*
+ * ProtocolBuffer Accessors
+ */
+
+void* decode_integer_to_pointer(fmi2Integer hi,fmi2Integer lo)
+{
+#if PTRDIFF_MAX == INT64_MAX
+	union addrconv {
+		struct {
+			int lo;
+			int hi;
+		} base;
+		unsigned long long address;
+	} myaddr;
+    myaddr.base.lo=lo;
+    myaddr.base.hi=hi;
+    return reinterpret_cast<void*>(myaddr.address);
+#elif PTRDIFF_MAX == INT32_MAX
+    return reinterpret_cast<void*>(lo);
+#else
+#error "Cannot determine 32bit or 64bit environment!"
+#endif
+}
+
+void encode_pointer_to_integer(const void* ptr,fmi2Integer& hi,fmi2Integer& lo)
+{
+#if PTRDIFF_MAX == INT64_MAX
+	union addrconv {
+		struct {
+			int lo;
+			int hi;
+		} base;
+		unsigned long long address;
+	} myaddr;
+    myaddr.address=reinterpret_cast<unsigned long long>(ptr);
+    hi=myaddr.base.hi;
+    lo=myaddr.base.lo;
+#elif PTRDIFF_MAX == INT32_MAX
+    hi=0;
+    lo=reinterpret_cast<int>(ptr);
+#else
+#error "Cannot determine 32bit or 64bit environment!"
+#endif
+}
+
+bool COSMPDummySensor::get_fmi_sensor_data_in(osi::SensorData& data)
+{
+    if (integer_vars[FMI_INTEGER_SENSORDATA_IN_SIZE_IDX] > 0) {
+		void* buffer = decode_integer_to_pointer(integer_vars[FMI_INTEGER_SENSORDATA_IN_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORDATA_IN_BASELO_IDX]);
+		private_log("Got %08X %08X, reading from %p ...",integer_vars[FMI_INTEGER_SENSORDATA_IN_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORDATA_IN_BASELO_IDX],buffer);
+		data.ParseFromArray(buffer,integer_vars[FMI_INTEGER_SENSORDATA_IN_SIZE_IDX]);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void COSMPDummySensor::set_fmi_sensor_data_out(const osi::SensorData& data)
+{
+    data.SerializeToString(&currentBuffer);
+    encode_pointer_to_integer(currentBuffer.data(),integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASELO_IDX]);
+	integer_vars[FMI_INTEGER_SENSORDATA_OUT_SIZE_IDX]=(fmi2Integer)currentBuffer.length();
+	private_log("Providing %08X %08X, writing from %p ...",integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASEHI_IDX],integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASELO_IDX],currentBuffer.data());
+	swap(currentBuffer,lastBuffer);
+}
+
+void COSMPDummySensor::reset_fmi_sensor_data_out()
+{
+	integer_vars[FMI_INTEGER_SENSORDATA_OUT_SIZE_IDX]=0;
+	integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASEHI_IDX]=0;
+    integer_vars[FMI_INTEGER_SENSORDATA_OUT_BASELO_IDX]=0;
+}
+
+/*
+ * Actual Core Content
+ */
+
+fmi2Status COSMPDummySensor::doInit()
+{
+	DEBUGBREAK();
+
+	/* Booleans */
+	for (int i = 0; i<FMI_BOOLEAN_VARS; i++)
+		boolean_vars[i] = fmi2False;
+
+	/* Integers */
+	for (int i = 0; i<FMI_INTEGER_VARS; i++)
+		integer_vars[i] = 0;
+
+	/* Reals */
+	for (int i = 0; i<FMI_REAL_VARS; i++)
+		real_vars[i] = 0.0;
+
+	/* Strings */
+	for (int i = 0; i<FMI_STRING_VARS; i++)
+		string_vars[i] = "";
+
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::doStart(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+{
+	DEBUGBREAK();
+	last_time = startTime;
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::doEnterInitializationMode()
+{
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::doExitInitializationMode()
+{
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::doCalc(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
+{
+	DEBUGBREAK();
+    osi::SensorData currentIn,currentOut;
+	if (fmi_source()) {
+		/* We act as SensorData Source, so ignore inputs */
+		currentOut.Clear();
+		currentOut.mutable_timestamp()->set_seconds((long long int)floor(currentCommunicationPoint));
+		currentOut.mutable_timestamp()->set_nanos((int)((currentCommunicationPoint - floor(currentCommunicationPoint))*1000000000.0));
+		for (unsigned int i=0;i<10;i++) {
+            osi::DetectedObject *obj = currentOut.add_object();
+			obj->mutable_tracking_id()->set_value(i);
+            obj->add_ground_truth_id()->set_value(i);
+			obj->set_existence_probability(0.5);
+		}
+        set_fmi_sensor_data_out(currentOut);
+        set_fmi_valid(true);
+        set_fmi_count(currentOut.object_size());
+    } else if (get_fmi_sensor_data_in(currentIn)) {
+		/* Clear Output */
+		currentOut.Clear();
+		/* Copy Everything */
+		currentOut.MergeFrom(currentIn);
+		/* Adjust Timestamps and Ids */
+		currentOut.mutable_timestamp()->set_seconds((long long int)floor(currentCommunicationPoint));
+		currentOut.mutable_timestamp()->set_nanos((int)((currentCommunicationPoint - floor(currentCommunicationPoint))*1000000000.0));
+		for_each(currentOut.mutable_object()->begin(),currentOut.mutable_object()->end(),
+            [this](osi::DetectedObject& obj) {
+				obj.mutable_tracking_id()->set_value(obj.tracking_id().value()+10);
+                obj.set_existence_probability(obj.existence_probability()*0.9);
+			});
+		/* Serialize */
+        set_fmi_sensor_data_out(currentOut);
+        set_fmi_valid(true);
+        set_fmi_count(currentOut.object_size());
+	} else {
+		/* We have no valid input, so no valid output */
+        reset_fmi_sensor_data_out();
+        set_fmi_valid(false);
+        set_fmi_count(0);
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::doTerm()
+{
+	DEBUGBREAK();
+	return fmi2OK;
+}
+
+void COSMPDummySensor::doFree()
+{
+	DEBUGBREAK();
+}
+
+/*
+ * Generic C++ Wrapper Code
+ */
+
+COSMPDummySensor::COSMPDummySensor(fmi2String theinstanceName, fmi2Type thefmuType, fmi2String thefmuGUID, fmi2String thefmuResourceLocation, const fmi2CallbackFunctions* thefunctions, fmi2Boolean thevisible, fmi2Boolean theloggingOn)
+	: instanceName(theinstanceName),
+	fmuType(thefmuType),
+	fmuGUID(thefmuGUID),
+	fmuResourceLocation(thefmuResourceLocation),
+	functions(*thefunctions),
+	visible(!!thevisible),
+	loggingOn(!!theloggingOn),
+	last_time(0.0)
+{
+
+}
+
+COSMPDummySensor::~COSMPDummySensor()
+{
+
+}
+
+
+fmi2Status COSMPDummySensor::SetDebugLogging(fmi2Boolean theloggingOn,size_t nCategories, const fmi2String categories[])
+{
+	private_log("fmi2SetDebugLogging(%s)", theloggingOn ? "true" : "false");
+	loggingOn = theloggingOn ? true : false;
+	return fmi2OK;
+}
+
+fmi2Component COSMPDummySensor::Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2String fmuGUID, fmi2String fmuResourceLocation, const fmi2CallbackFunctions* functions, fmi2Boolean visible, fmi2Boolean loggingOn)
+{
+	COSMPDummySensor* myc = new COSMPDummySensor(instanceName,fmuType,fmuGUID,fmuResourceLocation,functions,visible,loggingOn);
+
+	if (myc == NULL) {
+		private_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (alloc failure)",
+			instanceName, fmuType, fmuGUID,
+			(fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+			"FUNCTIONS", visible, loggingOn);
+		return NULL;
+	}
+
+	if (myc->doInit() != fmi2OK) {
+		private_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = NULL (doInit failure)",
+			instanceName, fmuType, fmuGUID,
+			(fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+			"FUNCTIONS", visible, loggingOn);
+		delete myc;
+		return NULL;
+	}
+	else {
+		private_log_global("fmi2Instantiate(\"%s\",%d,\"%s\",\"%s\",\"%s\",%d,%d) = %p",
+			instanceName, fmuType, fmuGUID,
+			(fmuResourceLocation != NULL) ? fmuResourceLocation : "<NULL>",
+			"FUNCTIONS", visible, loggingOn, myc);
+		return (fmi2Component)myc;
+	}
+}
+
+fmi2Status COSMPDummySensor::SetupExperiment(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
+{
+	private_log("fmi2SetupExperiment(%d,%g,%g,%d,%g)", toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+	return doStart(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+}
+
+fmi2Status COSMPDummySensor::EnterInitializationMode()
+{
+	private_log("fmi2EnterInitializationMode()");
+	return doEnterInitializationMode();
+}
+
+fmi2Status COSMPDummySensor::ExitInitializationMode()
+{
+	private_log("fmi2ExitInitializationMode()");
+	return doExitInitializationMode();
+}
+
+fmi2Status COSMPDummySensor::DoStep(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
+{
+	private_log("fmi2DoStep(%g,%g,%d)", currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+    return doCalc(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+}
+
+fmi2Status COSMPDummySensor::Terminate()
+{
+	private_log("fmi2Terminate()");
+	return doTerm();
+}
+
+fmi2Status COSMPDummySensor::Reset()
+{
+	private_log("fmi2Reset()");
+
+	doFree();
+	return doInit();
+}
+
+void COSMPDummySensor::FreeInstance()
+{
+	private_log("fmi2FreeInstance()");
+	doFree();
+}
+
+fmi2Status COSMPDummySensor::GetReal(const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
+{
+	private_log("fmi2GetReal(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_REAL_VARS)
+			value[i] = real_vars[vr[i]];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::GetInteger(const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
+{
+	private_log("fmi2GetInteger(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_INTEGER_VARS)
+			value[i] = integer_vars[vr[i]];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::GetBoolean(const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
+{
+	private_log("fmi2GetBoolean(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_BOOLEAN_VARS)
+			value[i] = boolean_vars[vr[i]];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::GetString(const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
+{
+	private_log("fmi2GetString(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_STRING_VARS)
+			value[i] = string_vars[vr[i]].c_str();
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::SetReal(const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
+{
+	private_log("fmi2SetReal(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_REAL_VARS)
+			real_vars[vr[i]] = value[i];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
+{
+	private_log("fmi2SetInteger(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_INTEGER_VARS)
+			integer_vars[vr[i]] = value[i];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
+{
+	private_log("fmi2SetBoolean(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_BOOLEAN_VARS)
+			boolean_vars[vr[i]] = value[i];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+fmi2Status COSMPDummySensor::SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
+{
+	private_log("fmi2SetString(...)");
+	for (size_t i = 0; i<nvr; i++) {
+		if (vr[i]<FMI_STRING_VARS)
+			string_vars[vr[i]] = value[i];
+		else
+			return fmi2Error;
+	}
+	return fmi2OK;
+}
+
+/*
+ * FMI 2.0 Co-Simulation Interface API
+ */
+
+extern "C" {
+
+	FMI2_Export const char* fmi2GetTypesPlatform()
+	{
+		return fmi2TypesPlatform;
+	}
+
+	FMI2_Export const char* fmi2GetVersion()
+	{
+		return fmi2Version;
+	}
+
+	FMI2_Export fmi2Status fmi2SetDebugLogging(fmi2Component c, fmi2Boolean loggingOn, size_t nCategories, const fmi2String categories[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetDebugLogging(loggingOn, nCategories, categories);
+	}
+
+	/*
+	* Functions for Co-Simulation
+	*/
+	FMI2_Export fmi2Component fmi2Instantiate(fmi2String instanceName,
+        fmi2Type fmuType,
+        fmi2String fmuGUID,
+        fmi2String fmuResourceLocation,
+        const fmi2CallbackFunctions* functions,
+        fmi2Boolean visible,
+        fmi2Boolean loggingOn)
+	{
+		return COSMPDummySensor::Instantiate(instanceName, fmuType, fmuGUID, fmuResourceLocation, functions, visible, loggingOn);
+	}
+
+	FMI2_Export fmi2Status fmi2SetupExperiment(fmi2Component c,
+        fmi2Boolean toleranceDefined,
+        fmi2Real tolerance,
+        fmi2Real startTime,
+        fmi2Boolean stopTimeDefined,
+        fmi2Real stopTime)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetupExperiment(toleranceDefined, tolerance, startTime, stopTimeDefined, stopTime);
+	}
+
+	FMI2_Export fmi2Status fmi2EnterInitializationMode(fmi2Component c)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->EnterInitializationMode();
+	}
+
+	FMI2_Export fmi2Status fmi2ExitInitializationMode(fmi2Component c)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->ExitInitializationMode();
+	}
+
+	FMI2_Export fmi2Status fmi2DoStep(fmi2Component c,
+        fmi2Real currentCommunicationPoint,
+        fmi2Real communicationStepSize,
+        fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->DoStep(currentCommunicationPoint, communicationStepSize, noSetFMUStatePriorToCurrentPointfmi2Component);
+	}
+
+	FMI2_Export fmi2Status fmi2Terminate(fmi2Component c)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->Terminate();
+	}
+
+	FMI2_Export fmi2Status fmi2Reset(fmi2Component c)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->Reset();
+	}
+
+	FMI2_Export void fmi2FreeInstance(fmi2Component c)
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		myc->FreeInstance();
+		delete myc;
+	}
+
+	/*
+	 * Data Exchange Functions
+	 */
+	FMI2_Export fmi2Status fmi2GetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->GetReal(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2GetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->GetInteger(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2GetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->GetBoolean(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2GetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->GetString(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2SetReal(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetReal(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2SetInteger(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetInteger(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2SetBoolean(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetBoolean(vr, nvr, value);
+	}
+
+	FMI2_Export fmi2Status fmi2SetString(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String value[])
+	{
+		COSMPDummySensor* myc = (COSMPDummySensor*)c;
+		return myc->SetString(vr, nvr, value);
+	}
+
+	/*
+	 * Unsupported Features (FMUState, Derivatives, Async DoStep, Status Enquiries)
+	 */
+	FMI2_Export fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2SetFMUstate(fmi2Component c, fmi2FMUstate FMUstate)
+	{
+		return fmi2Error;
+	}
+
+    FMI2_Export fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate FMUstate, size_t *size)
+	{
+		return fmi2Error;
+	}
+
+    FMI2_Export fmi2Status fmi2SerializeFMUstate (fmi2Component c, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
+	{
+		return fmi2Error;
+	}
+
+    FMI2_Export fmi2Status fmi2DeSerializeFMUstate (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2GetDirectionalDerivative(fmi2Component c,
+        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
+        const fmi2ValueReference vKnown_ref[] , size_t nKnown,
+        const fmi2Real dvKnown[],
+        fmi2Real dvUnknown[])
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2SetRealInputDerivatives(fmi2Component c,
+		const  fmi2ValueReference vr[],
+		size_t nvr,
+		const  fmi2Integer order[],
+		const  fmi2Real value[])
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2GetRealOutputDerivatives(fmi2Component c,
+		const   fmi2ValueReference vr[],
+		size_t  nvr,
+		const   fmi2Integer order[],
+		fmi2Real value[])
+	{
+		return fmi2Error;
+	}
+
+	FMI2_Export fmi2Status fmi2CancelStep(fmi2Component c)
+	{
+		return fmi2OK;
+	}
+
+	FMI2_Export fmi2Status fmi2GetStatus(fmi2Component c, const fmi2StatusKind s, fmi2Status* value)
+	{
+		return fmi2Discard;
+	}
+
+	FMI2_Export fmi2Status fmi2GetRealStatus(fmi2Component c, const fmi2StatusKind s, fmi2Real* value)
+	{
+		return fmi2Discard;
+	}
+
+	FMI2_Export fmi2Status fmi2GetIntegerStatus(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value)
+	{
+		return fmi2Discard;
+	}
+
+	FMI2_Export fmi2Status fmi2GetBooleanStatus(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value)
+	{
+		return fmi2Discard;
+	}
+
+	FMI2_Export fmi2Status fmi2GetStringStatus(fmi2Component c, const fmi2StatusKind s, fmi2String* value)
+	{
+		return fmi2Discard;
+	}
+
+}

--- a/examples/OSMPDummySensor/OSMPDummySensor.h
+++ b/examples/OSMPDummySensor/OSMPDummySensor.h
@@ -1,0 +1,177 @@
+/*
+ * PMSF FMU Framework for FMI 2.0 Co-Simulation FMUs
+ *
+ * (C) 2016 -- 2017 PMSF IT Consulting Pierre R. Mai
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+using namespace std;
+
+#include "fmi2Functions.h"
+
+/* Enable Logging to File for Debug Builds */
+#ifndef NDEBUG
+#ifdef _WIN32
+#define PRIVATE_LOG_PATH "C:\\TEMP\\OSMPDummySensorLog.log"
+#else
+#define PRIVATE_LOG_PATH "/tmp/OSMPDummySensorLog.log"
+#endif
+#endif
+
+/*
+ * Variable Definitions
+ *
+ * Define FMI_*_LAST_IDX to the zero-based index of the last variable
+ * of the given type (0 if no variables of the type exist).  This
+ * ensures proper space allocation, initialisation and handling of
+ * the given variables in the template code.  Optionally you can
+ * define FMI_TYPENAME_VARNAME_IDX definitions (e.g. FMI_REAL_MYVAR_IDX)
+ * to refer to individual variables inside your code, or for example
+ * FMI_REAL_MYARRAY_OFFSET and FMI_REAL_MYARRAY_SIZE definitions for
+ * array variables.
+ */
+
+/* Boolean Variables */
+#define FMI_BOOLEAN_SOURCE_IDX 0
+#define FMI_BOOLEAN_VALID_IDX 1
+#define FMI_BOOLEAN_LAST_IDX FMI_BOOLEAN_VALID_IDX
+#define FMI_BOOLEAN_VARS (FMI_BOOLEAN_LAST_IDX+1)
+
+/* Integer Variables */
+#define FMI_INTEGER_SENSORDATA_IN_BASELO_IDX 0
+#define FMI_INTEGER_SENSORDATA_IN_BASEHI_IDX 1
+#define FMI_INTEGER_SENSORDATA_IN_SIZE_IDX 2
+#define FMI_INTEGER_SENSORDATA_OUT_BASELO_IDX 3
+#define FMI_INTEGER_SENSORDATA_OUT_BASEHI_IDX 4
+#define FMI_INTEGER_SENSORDATA_OUT_SIZE_IDX 5
+#define FMI_INTEGER_COUNT_IDX 6
+#define FMI_INTEGER_LAST_IDX FMI_INTEGER_COUNT_IDX
+#define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
+
+/* Real Variables */
+#define FMI_REAL_LAST_IDX 0
+#define FMI_REAL_VARS (FMI_REAL_LAST_IDX+1)
+
+/* String Variables */
+#define FMI_STRING_LAST_IDX 0
+#define FMI_STRING_VARS (FMI_STRING_LAST_IDX+1)
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <cstdarg>
+
+#undef min
+#undef max
+#include "osi_sensordata.pb.h"
+
+/* FMU Class */
+class COSMPDummySensor {
+public:
+	/* FMI2 Interface mapped to C++ */
+    COSMPDummySensor(fmi2String theinstanceName, fmi2Type thefmuType, fmi2String thefmuGUID, fmi2String thefmuResourceLocation, const fmi2CallbackFunctions* thefunctions, fmi2Boolean thevisible, fmi2Boolean theloggingOn);
+	~COSMPDummySensor();
+    fmi2Status SetDebugLogging(fmi2Boolean theloggingOn,size_t nCategories, const fmi2String categories[]);
+	static fmi2Component Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2String fmuGUID, fmi2String fmuResourceLocation, const fmi2CallbackFunctions* functions, fmi2Boolean visible, fmi2Boolean loggingOn);
+    fmi2Status SetupExperiment(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
+	fmi2Status EnterInitializationMode();
+	fmi2Status ExitInitializationMode();
+	fmi2Status DoStep(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component);
+	fmi2Status Terminate();
+	fmi2Status Reset();
+	void FreeInstance();
+	fmi2Status GetReal(const fmi2ValueReference vr[], size_t nvr, fmi2Real value[]);
+	fmi2Status GetInteger(const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[]);
+	fmi2Status GetBoolean(const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[]);
+	fmi2Status GetString(const fmi2ValueReference vr[], size_t nvr, fmi2String value[]);
+	fmi2Status SetReal(const fmi2ValueReference vr[], size_t nvr, const fmi2Real value[]);
+	fmi2Status SetInteger(const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
+	fmi2Status SetBoolean(const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
+	fmi2Status SetString(const fmi2ValueReference vr[], size_t nvr, const fmi2String value[]);
+
+protected:
+	/* Internal Implementation */
+	fmi2Status doInit();
+	fmi2Status doStart(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime);
+	fmi2Status doEnterInitializationMode();
+	fmi2Status doExitInitializationMode();
+	fmi2Status doCalc(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component);
+	fmi2Status doTerm();
+	void doFree();
+
+protected:
+	/* Private File-based Logging just for Debugging */
+#ifdef PRIVATE_LOG_PATH
+	static ofstream private_log_file;
+#endif
+
+	static void private_log_global(const char* format, ...) {
+#ifdef PRIVATE_LOG_PATH
+		va_list ap;
+		va_start(ap, format);
+		char buffer[1024];
+		if (!private_log_file.is_open())
+			private_log_file.open(PRIVATE_LOG_PATH, ios::out | ios::app);
+		if (private_log_file.is_open()) {
+#ifdef _WIN32
+			vsnprintf_s(buffer, 1024, format, ap);
+#else
+			vsnprintf(buffer, 1024, format, ap);
+#endif
+			private_log_file << "OSMPDummySensor" << "::Global: " << buffer << endl;
+			private_log_file.flush();
+		}
+#endif
+	}
+	void private_log(const char* format, ...) {
+#ifdef PRIVATE_LOG_PATH
+		va_list ap;
+		va_start(ap, format);
+		char buffer[1024];
+		if (!private_log_file.is_open())
+			private_log_file.open(PRIVATE_LOG_PATH, ios::out | ios::app);
+		if (private_log_file.is_open()) {
+#ifdef _WIN32
+			vsnprintf_s(buffer, 1024, format, ap);
+#else
+			vsnprintf(buffer, 1024, format, ap);
+#endif
+			private_log_file << "OSMPDummySensor" << "::" << instanceName << "<" << ((void*)this) << ">: " << buffer << endl;
+			private_log_file.flush();
+		}
+#endif
+	}
+
+protected:
+	/* Members */
+	string instanceName;
+	fmi2Type fmuType;
+	string fmuGUID;
+	string fmuResourceLocation;
+	bool visible;
+	bool loggingOn;
+	fmi2CallbackFunctions functions;
+	fmi2Boolean boolean_vars[FMI_BOOLEAN_VARS];
+	fmi2Integer integer_vars[FMI_INTEGER_VARS];
+	fmi2Real real_vars[FMI_REAL_VARS];
+	string string_vars[FMI_STRING_VARS];
+	double last_time;
+	string currentBuffer;
+	string lastBuffer;
+
+    /* Simple Accessors */
+    fmi2Boolean fmi_source() { return boolean_vars[FMI_BOOLEAN_SOURCE_IDX]; }
+    void set_fmi_source(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_SOURCE_IDX]=value; }
+    fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }
+    void set_fmi_valid(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_VALID_IDX]=value; }
+    fmi2Integer fmi_count() { return integer_vars[FMI_INTEGER_COUNT_IDX]; }
+    void set_fmi_count(fmi2Integer value) { integer_vars[FMI_INTEGER_COUNT_IDX]=value; }
+
+    /* Protocol Buffer Accessors */
+    bool get_fmi_sensor_data_in(osi::SensorData& data);
+    void set_fmi_sensor_data_out(const osi::SensorData& data);
+    void reset_fmi_sensor_data_out();
+};

--- a/examples/OSMPDummySensor/modelDescription.xml
+++ b/examples/OSMPDummySensor/modelDescription.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fmiModelDescription
+  fmiVersion="2.0"
+  modelName="OSMP Dummy Sensor FMU"
+  guid="1756ade4e20f08597cfae6947c96bf86"
+  description="Demonstration C++ FMU for OSI Sensor Model Packaging"
+  author="PMSF"
+  version="1.0"
+  generationTool="PMSF Manual FMU Framework"
+  generationDateAndTime="2017-02-05T16:13:42Z"
+  variableNamingConvention="structured">
+  <CoSimulation
+    modelIdentifier="OSMPDummySensor"
+    canHandleVariableCommunicationStepSize="true"
+    canNotUseMemoryManagementFunctions="true"/>
+  <DefaultExperiment startTime="0.0" stepSize="0.020"/>
+  <VendorAnnotations>
+    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="0.1"/></Tool>
+  </VendorAnnotations>
+  <ModelVariables>
+    <ScalarVariable name="OSMPSensorDataIn.base.lo" valueReference="0" causality="input" variability="discrete">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorDataIn.base.hi" valueReference="1" causality="input" variability="discrete">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorDataIn.size" valueReference="2" causality="input" variability="discrete">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorDataOut.base.lo" valueReference="3" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorDataOut.base.hi" valueReference="4" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorDataOut.size" valueReference="5" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="source" valueReference="0" causality="parameter" variability="fixed">
+      <Boolean start="false"/>
+    </ScalarVariable>
+    <ScalarVariable name="valid" valueReference="1" causality="output" variability="discrete" initial="exact">
+      <Boolean start="false"/>
+    </ScalarVariable>
+    <ScalarVariable name="count" valueReference="6" causality="output" variability="discrete" initial="exact">
+      <Integer start="0"/>
+    </ScalarVariable>
+  </ModelVariables>
+  <ModelStructure>
+    <Outputs>
+      <Unknown index="4"/>
+      <Unknown index="5"/>
+      <Unknown index="6"/>
+      <Unknown index="8"/>
+      <Unknown index="9"/>
+    </Outputs>
+  </ModelStructure>
+</fmiModelDescription>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+OSI Sensor Model Packaging Examples
+===================================
+
+The examples in this directory can be built using CMake.
+They require that the open-simulation-interface submodule
+of the repository is populated.
+

--- a/examples/includes/fmi2FunctionTypes.h
+++ b/examples/includes/fmi2FunctionTypes.h
@@ -1,0 +1,243 @@
+#ifndef fmi2FunctionTypes_h
+#define fmi2FunctionTypes_h
+
+#include "fmi2TypesPlatform.h"
+
+/* This header file must be utilized when compiling an FMU or an FMI master.
+   It declares data and function types for FMI 2.0
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Apr.  3, 2014: Added #include <stddef.h> for size_t definition
+   - Mar. 27, 2014: Added #include "fmiTypesPlatform.h" (#179)
+   - Mar. 26, 2014: Introduced function argument "void" for the functions (#171)
+                      fmiGetTypesPlatformTYPE and fmiGetVersionTYPE
+   - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
+                      fmiInstantiateModelTYPE , fmiInstantiateSlaveTYPE  -> fmiInstantiateTYPE
+                      fmiFreeModelInstanceTYPE, fmiFreeSlaveInstanceTYPE -> fmiFreeInstanceTYPE
+                      fmiEnterModelInitializationModeTYPE, fmiEnterSlaveInitializationModeTYPE -> fmiEnterInitializationModeTYPE
+                      fmiExitModelInitializationModeTYPE , fmiExitSlaveInitializationModeTYPE  -> fmiExitInitializationModeTYPE
+                      fmiTerminateModelTYPE , fmiTerminateSlaveTYPE  -> fmiTerminate
+                      fmiResetSlave -> fmiReset (now also for ModelExchange and not only for CoSimulation)
+                    Functions renamed
+                      fmiUpdateDiscreteStatesTYPE -> fmiNewDiscreteStatesTYPE
+                    Renamed elements of the enumeration fmiEventInfo
+                      upcomingTimeEvent             -> nextEventTimeDefined // due to generic naming scheme: varDefined + var
+                      newUpdateDiscreteStatesNeeded -> newDiscreteStatesNeeded;
+   - June 13, 2013: Changed type fmiEventInfo
+                    Functions removed:
+                       fmiInitializeModelTYPE
+                       fmiEventUpdateTYPE
+                       fmiCompletedEventIterationTYPE
+                       fmiInitializeSlaveTYPE
+                    Functions added:
+                       fmiEnterModelInitializationModeTYPE
+                       fmiExitModelInitializationModeTYPE
+                       fmiEnterEventModeTYPE
+                       fmiUpdateDiscreteStatesTYPE
+                       fmiEnterContinuousTimeModeTYPE
+                       fmiEnterSlaveInitializationModeTYPE;
+                       fmiExitSlaveInitializationModeTYPE;
+   - Feb. 17, 2013: Added third argument to fmiCompletedIntegratorStepTYPE
+                    Changed function name "fmiTerminateType" to "fmiTerminateModelType" (due to #113)
+                    Changed function name "fmiGetNominalContinuousStateTYPE" to
+                                          "fmiGetNominalsOfContinuousStatesTYPE"
+                    Removed fmiGetStateValueReferencesTYPE.
+   - Nov. 14, 2011: First public Version
+
+
+   Copyright © 2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* make sure all compiler use the same alignment policies for structures */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(push,8)
+#endif
+
+/* Include stddef.h, in order that size_t etc. is defined */
+#include <stddef.h>
+
+
+/* Type definitions */
+typedef enum {
+    fmi2OK,
+    fmi2Warning,
+    fmi2Discard,
+    fmi2Error,
+    fmi2Fatal,
+    fmi2Pending
+} fmi2Status;
+
+typedef enum {
+    fmi2ModelExchange,
+    fmi2CoSimulation
+} fmi2Type;
+
+typedef enum {
+    fmi2DoStepStatus,
+    fmi2PendingStatus,
+    fmi2LastSuccessfulTime,
+    fmi2Terminated
+} fmi2StatusKind;
+
+typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment, fmi2String, fmi2Status, fmi2String, fmi2String, ...);
+typedef void*     (*fmi2CallbackAllocateMemory)(size_t, size_t);
+typedef void      (*fmi2CallbackFreeMemory)    (void*);
+typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment, fmi2Status);
+
+typedef struct {
+   const fmi2CallbackLogger         logger;
+   const fmi2CallbackAllocateMemory allocateMemory;
+   const fmi2CallbackFreeMemory     freeMemory;
+   const fmi2StepFinished           stepFinished;
+   const fmi2ComponentEnvironment   componentEnvironment;
+} fmi2CallbackFunctions;
+
+typedef struct {
+	 fmi2Boolean newDiscreteStatesNeeded;
+   fmi2Boolean terminateSimulation;
+   fmi2Boolean nominalsOfContinuousStatesChanged;
+   fmi2Boolean valuesOfContinuousStatesChanged;
+   fmi2Boolean nextEventTimeDefined;
+   fmi2Real    nextEventTime;
+} fmi2EventInfo;
+
+
+/* reset alignment policy to the one set before reading this file */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(pop)
+#endif
+
+
+/* Define fmi2 function pointer types to simplify dynamic loading */
+
+/***************************************************
+Types for Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files and setting logging status */
+   typedef const char* fmi2GetTypesPlatformTYPE(void);
+   typedef const char* fmi2GetVersionTYPE(void);
+   typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component, fmi2Boolean, size_t, const fmi2String[]);
+
+/* Creation and destruction of FMU instances and setting debug status */
+   typedef fmi2Component fmi2InstantiateTYPE (fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*, fmi2Boolean, fmi2Boolean);
+   typedef void          fmi2FreeInstanceTYPE(fmi2Component);
+
+/* Enter and exit initialization mode, terminate and reset */
+   typedef fmi2Status fmi2SetupExperimentTYPE        (fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
+   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component);
+   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component);
+   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component);
+   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component);
+
+/* Getting and setting variable values */
+   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, fmi2Real   []);
+   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Integer[]);
+   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Boolean[]);
+   typedef fmi2Status fmi2GetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, fmi2String []);
+
+   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, const fmi2Real   []);
+   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Integer[]);
+   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
+   typedef fmi2Status fmi2SetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, const fmi2String []);
+
+/* Getting and setting the internal FMU state */
+   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component, fmi2FMUstate*);
+   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component, fmi2FMUstate);
+   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component, fmi2FMUstate*);
+   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component, fmi2FMUstate, size_t*);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component, fmi2FMUstate, fmi2Byte[], size_t);
+   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component, const fmi2Byte[], size_t, fmi2FMUstate*);
+
+/* Getting partial derivatives */
+   typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component, const fmi2ValueReference[], size_t,
+                                                                   const fmi2ValueReference[], size_t,
+                                                                   const fmi2Real[], fmi2Real[]);
+
+/***************************************************
+Types for Functions for FMI2 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component);
+   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component, fmi2EventInfo*);
+   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component);
+   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+
+/* Providing independent variables and re-initialization of caching */
+   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component, fmi2Real);
+   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component, const fmi2Real[], size_t);
+
+/* Evaluation of the model equations */
+   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component, fmi2Real[], size_t);
+
+
+/***************************************************
+Types for Functions for FMI2 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+   typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], const fmi2Real []);
+   typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], fmi2Real []);
+
+   typedef fmi2Status fmi2DoStepTYPE     (fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
+   typedef fmi2Status fmi2CancelStepTYPE (fmi2Component);
+
+/* Inquire slave status */
+   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component, const fmi2StatusKind, fmi2Status* );
+   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component, const fmi2StatusKind, fmi2Real*   );
+   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Integer*);
+   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
+   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component, const fmi2StatusKind, fmi2String* );
+
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi2FunctionTypes_h */

--- a/examples/includes/fmi2Functions.h
+++ b/examples/includes/fmi2Functions.h
@@ -1,0 +1,333 @@
+#ifndef fmi2Functions_h
+#define fmi2Functions_h
+
+/* This header file must be utilized when compiling a FMU.
+   It defines all functions of the
+         FMI 2.0 Model Exchange and Co-Simulation Interface.
+
+   In order to have unique function names even if several FMUs
+   are compiled together (e.g. for embedded systems), every "real" function name
+   is constructed by prepending the function name by "FMI2_FUNCTION_PREFIX".
+   Therefore, the typical usage is:
+
+      #define FMI2_FUNCTION_PREFIX MyModel_
+      #include "fmi2Functions.h"
+
+   As a result, a function that is defined as "fmi2GetDerivatives" in this header file,
+   is actually getting the name "MyModel_fmi2GetDerivatives".
+
+   This only holds if the FMU is shipped in C source code, or is compiled in a
+   static link library. For FMUs compiled in a DLL/sharedObject, the "actual" function
+   names are used and "FMI2_FUNCTION_PREFIX" must not be defined.
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Mar. 26, 2014: FMI_Export set to empty value if FMI_Export and FMI_FUNCTION_PREFIX
+                    are not defined (#173)
+   - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
+                      fmiInstantiateModel , fmiInstantiateSlave  -> fmiInstantiate
+                      fmiFreeModelInstance, fmiFreeSlaveInstance -> fmiFreeInstance
+                      fmiEnterModelInitializationMode, fmiEnterSlaveInitializationMode -> fmiEnterInitializationMode
+                      fmiExitModelInitializationMode , fmiExitSlaveInitializationMode  -> fmiExitInitializationMode
+                      fmiTerminateModel, fmiTerminateSlave  -> fmiTerminate
+                      fmiResetSlave -> fmiReset (now also for ModelExchange and not only for CoSimulation)
+                    Functions renamed:
+                      fmiUpdateDiscreteStates -> fmiNewDiscreteStates
+   - June 13, 2013: Functions removed:
+                       fmiInitializeModel
+                       fmiEventUpdate
+                       fmiCompletedEventIteration
+                       fmiInitializeSlave
+                    Functions added:
+                       fmiEnterModelInitializationMode
+                       fmiExitModelInitializationMode
+                       fmiEnterEventMode
+                       fmiUpdateDiscreteStates
+                       fmiEnterContinuousTimeMode
+                       fmiEnterSlaveInitializationMode;
+                       fmiExitSlaveInitializationMode;
+   - Feb. 17, 2013: Portability improvements:
+                       o DllExport changed to FMI_Export
+                       o FUNCTION_PREFIX changed to FMI_FUNCTION_PREFIX
+                       o Allow undefined FMI_FUNCTION_PREFIX (meaning no prefix is used)
+                    Changed function name "fmiTerminate" to "fmiTerminateModel" (due to #113)
+                    Changed function name "fmiGetNominalContinuousState" to
+                                          "fmiGetNominalsOfContinuousStates"
+                    Removed fmiGetStateValueReferences.
+   - Nov. 14, 2011: Adapted to FMI 2.0:
+                       o Split into two files (fmiFunctions.h, fmiTypes.h) in order
+                         that code that dynamically loads an FMU can directly
+                         utilize the header files).
+                       o Added C++ encapsulation of C-part, in order that the header
+                         file can be directly utilized in C++ code.
+                       o fmiCallbackFunctions is passed as pointer to fmiInstantiateXXX
+                       o stepFinished within fmiCallbackFunctions has as first
+                         argument "fmiComponentEnvironment" and not "fmiComponent".
+                       o New functions to get and set the complete FMU state
+                         and to compute partial derivatives.
+   - Nov.  4, 2010: Adapted to specification text:
+                       o fmiGetModelTypesPlatform renamed to fmiGetTypesPlatform
+                       o fmiInstantiateSlave: Argument GUID     replaced by fmuGUID
+                                              Argument mimetype replaced by mimeType
+                       o tabs replaced by spaces
+   - Oct. 16, 2010: Functions for FMI for Co-simulation added
+   - Jan. 20, 2010: stateValueReferencesChanged added to struct fmiEventInfo (ticket #27)
+                    (by M. Otter, DLR)
+                    Added WIN32 pragma to define the struct layout (ticket #34)
+                    (by J. Mauss, QTronic)
+   - Jan.  4, 2010: Removed argument intermediateResults from fmiInitialize
+                    Renamed macro fmiGetModelFunctionsVersion to fmiGetVersion
+                    Renamed macro fmiModelFunctionsVersion to fmiVersion
+                    Replaced fmiModel by fmiComponent in decl of fmiInstantiateModel
+                    (by J. Mauss, QTronic)
+   - Dec. 17, 2009: Changed extension "me" to "fmi" (by Martin Otter, DLR).
+   - Dez. 14, 2009: Added eventInfo to meInitialize and added
+                    meGetNominalContinuousStates (by Martin Otter, DLR)
+   - Sept. 9, 2009: Added DllExport (according to Peter Nilsson's suggestion)
+                    (by A. Junghanns, QTronic)
+   - Sept. 9, 2009: Changes according to FMI-meeting on July 21:
+                    meInquireModelTypesVersion     -> meGetModelTypesPlatform
+                    meInquireModelFunctionsVersion -> meGetModelFunctionsVersion
+                    meSetStates                    -> meSetContinuousStates
+                    meGetStates                    -> meGetContinuousStates
+                    removal of meInitializeModelClass
+                    removal of meGetTime
+                    change of arguments of meInstantiateModel
+                    change of arguments of meCompletedIntegratorStep
+                    (by Martin Otter, DLR):
+   - July 19, 2009: Added "me" as prefix to file names (by Martin Otter, DLR).
+   - March 2, 2009: Changed function definitions according to the last design
+                    meeting with additional improvements (by Martin Otter, DLR).
+   - Dec. 3 , 2008: First version by Martin Otter (DLR) and Hans Olsson (Dynasim).
+
+   Copyright © 2008-2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fmi2TypesPlatform.h"
+#include "fmi2FunctionTypes.h"
+#include <stdlib.h>
+
+
+/*
+  Export FMI2 API functions on Windows and under GCC.
+  If custom linking is desired then the FMI2_Export must be
+  defined before including this file. For instance,
+  it may be set to __declspec(dllimport).
+*/
+#if !defined(FMI2_Export)
+  #if !defined(FMI2_FUNCTION_PREFIX)
+    #if defined _WIN32 || defined __CYGWIN__
+     /* Note: both gcc & MSVC on Windows support this syntax. */
+        #define FMI2_Export __declspec(dllexport)
+    #else
+      #if __GNUC__ >= 4
+        #define FMI2_Export __attribute__ ((visibility ("default")))
+      #else
+        #define FMI2_Export
+      #endif
+    #endif
+  #else
+    #define FMI2_Export
+  #endif
+#endif
+
+/* Macros to construct the real function name
+   (prepend function name by FMI2_FUNCTION_PREFIX) */
+#if defined(FMI2_FUNCTION_PREFIX)
+  #define fmi2Paste(a,b)     a ## b
+  #define fmi2PasteB(a,b)    fmi2Paste(a,b)
+  #define fmi2FullName(name) fmi2PasteB(FMI2_FUNCTION_PREFIX, name)
+#else
+  #define fmi2FullName(name) name
+#endif
+
+/***************************************************
+Common Functions
+****************************************************/
+#define fmi2GetTypesPlatform         fmi2FullName(fmi2GetTypesPlatform)
+#define fmi2GetVersion               fmi2FullName(fmi2GetVersion)
+#define fmi2SetDebugLogging          fmi2FullName(fmi2SetDebugLogging)
+#define fmi2Instantiate              fmi2FullName(fmi2Instantiate)
+#define fmi2FreeInstance             fmi2FullName(fmi2FreeInstance)
+#define fmi2SetupExperiment          fmi2FullName(fmi2SetupExperiment)
+#define fmi2EnterInitializationMode  fmi2FullName(fmi2EnterInitializationMode)
+#define fmi2ExitInitializationMode   fmi2FullName(fmi2ExitInitializationMode)
+#define fmi2Terminate                fmi2FullName(fmi2Terminate)
+#define fmi2Reset                    fmi2FullName(fmi2Reset)
+#define fmi2GetReal                  fmi2FullName(fmi2GetReal)
+#define fmi2GetInteger               fmi2FullName(fmi2GetInteger)
+#define fmi2GetBoolean               fmi2FullName(fmi2GetBoolean)
+#define fmi2GetString                fmi2FullName(fmi2GetString)
+#define fmi2SetReal                  fmi2FullName(fmi2SetReal)
+#define fmi2SetInteger               fmi2FullName(fmi2SetInteger)
+#define fmi2SetBoolean               fmi2FullName(fmi2SetBoolean)
+#define fmi2SetString                fmi2FullName(fmi2SetString)
+#define fmi2GetFMUstate              fmi2FullName(fmi2GetFMUstate)
+#define fmi2SetFMUstate              fmi2FullName(fmi2SetFMUstate)
+#define fmi2FreeFMUstate             fmi2FullName(fmi2FreeFMUstate)
+#define fmi2SerializedFMUstateSize   fmi2FullName(fmi2SerializedFMUstateSize)
+#define fmi2SerializeFMUstate        fmi2FullName(fmi2SerializeFMUstate)
+#define fmi2DeSerializeFMUstate      fmi2FullName(fmi2DeSerializeFMUstate)
+#define fmi2GetDirectionalDerivative fmi2FullName(fmi2GetDirectionalDerivative)
+
+
+/***************************************************
+Functions for FMI2 for Model Exchange
+****************************************************/
+#define fmi2EnterEventMode                fmi2FullName(fmi2EnterEventMode)
+#define fmi2NewDiscreteStates             fmi2FullName(fmi2NewDiscreteStates)
+#define fmi2EnterContinuousTimeMode       fmi2FullName(fmi2EnterContinuousTimeMode)
+#define fmi2CompletedIntegratorStep       fmi2FullName(fmi2CompletedIntegratorStep)
+#define fmi2SetTime                       fmi2FullName(fmi2SetTime)
+#define fmi2SetContinuousStates           fmi2FullName(fmi2SetContinuousStates)
+#define fmi2GetDerivatives                fmi2FullName(fmi2GetDerivatives)
+#define fmi2GetEventIndicators            fmi2FullName(fmi2GetEventIndicators)
+#define fmi2GetContinuousStates           fmi2FullName(fmi2GetContinuousStates)
+#define fmi2GetNominalsOfContinuousStates fmi2FullName(fmi2GetNominalsOfContinuousStates)
+
+
+/***************************************************
+Functions for FMI2 for Co-Simulation
+****************************************************/
+#define fmi2SetRealInputDerivatives      fmi2FullName(fmi2SetRealInputDerivatives)
+#define fmi2GetRealOutputDerivatives     fmi2FullName(fmi2GetRealOutputDerivatives)
+#define fmi2DoStep                       fmi2FullName(fmi2DoStep)
+#define fmi2CancelStep                   fmi2FullName(fmi2CancelStep)
+#define fmi2GetStatus                    fmi2FullName(fmi2GetStatus)
+#define fmi2GetRealStatus                fmi2FullName(fmi2GetRealStatus)
+#define fmi2GetIntegerStatus             fmi2FullName(fmi2GetIntegerStatus)
+#define fmi2GetBooleanStatus             fmi2FullName(fmi2GetBooleanStatus)
+#define fmi2GetStringStatus              fmi2FullName(fmi2GetStringStatus)
+
+/* Version number */
+#define fmi2Version "2.0"
+
+
+/***************************************************
+Common Functions
+****************************************************/
+
+/* Inquire version numbers of header files */
+   FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
+   FMI2_Export fmi2GetVersionTYPE       fmi2GetVersion;
+   FMI2_Export fmi2SetDebugLoggingTYPE  fmi2SetDebugLogging;
+
+/* Creation and destruction of FMU instances */
+   FMI2_Export fmi2InstantiateTYPE  fmi2Instantiate;
+   FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
+
+/* Enter and exit initialization mode, terminate and reset */
+   FMI2_Export fmi2SetupExperimentTYPE         fmi2SetupExperiment;
+   FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
+   FMI2_Export fmi2ExitInitializationModeTYPE  fmi2ExitInitializationMode;
+   FMI2_Export fmi2TerminateTYPE               fmi2Terminate;
+   FMI2_Export fmi2ResetTYPE                   fmi2Reset;
+
+/* Getting and setting variables values */
+   FMI2_Export fmi2GetRealTYPE    fmi2GetReal;
+   FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
+   FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
+   FMI2_Export fmi2GetStringTYPE  fmi2GetString;
+
+   FMI2_Export fmi2SetRealTYPE    fmi2SetReal;
+   FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
+   FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
+   FMI2_Export fmi2SetStringTYPE  fmi2SetString;
+
+/* Getting and setting the internal FMU state */
+   FMI2_Export fmi2GetFMUstateTYPE            fmi2GetFMUstate;
+   FMI2_Export fmi2SetFMUstateTYPE            fmi2SetFMUstate;
+   FMI2_Export fmi2FreeFMUstateTYPE           fmi2FreeFMUstate;
+   FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
+   FMI2_Export fmi2SerializeFMUstateTYPE      fmi2SerializeFMUstate;
+   FMI2_Export fmi2DeSerializeFMUstateTYPE    fmi2DeSerializeFMUstate;
+
+/* Getting partial derivatives */
+   FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
+
+
+/***************************************************
+Functions for FMI2 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+   FMI2_Export fmi2EnterEventModeTYPE               fmi2EnterEventMode;
+   FMI2_Export fmi2NewDiscreteStatesTYPE            fmi2NewDiscreteStates;
+   FMI2_Export fmi2EnterContinuousTimeModeTYPE      fmi2EnterContinuousTimeMode;
+   FMI2_Export fmi2CompletedIntegratorStepTYPE      fmi2CompletedIntegratorStep;
+
+/* Providing independent variables and re-initialization of caching */
+   FMI2_Export fmi2SetTimeTYPE             fmi2SetTime;
+   FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
+
+/* Evaluation of the model equations */
+   FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
+   FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
+   FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
+   FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
+
+
+/***************************************************
+Functions for FMI2 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+   FMI2_Export fmi2SetRealInputDerivativesTYPE  fmi2SetRealInputDerivatives;
+   FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
+
+   FMI2_Export fmi2DoStepTYPE     fmi2DoStep;
+   FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
+
+/* Inquire slave status */
+   FMI2_Export fmi2GetStatusTYPE        fmi2GetStatus;
+   FMI2_Export fmi2GetRealStatusTYPE    fmi2GetRealStatus;
+   FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
+   FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
+   FMI2_Export fmi2GetStringStatusTYPE  fmi2GetStringStatus;
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi2Functions_h */

--- a/examples/includes/fmi2TypesPlatform.h
+++ b/examples/includes/fmi2TypesPlatform.h
@@ -1,0 +1,115 @@
+#ifndef fmi2TypesPlatform_h
+#define fmi2TypesPlatform_h
+
+/* Standard header file to define the argument types of the
+   functions of the Functional Mock-up Interface 2.0.
+   This header file must be utilized both by the model and
+   by the simulation engine.
+
+   Revisions:
+   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Mar   31, 2014: New datatype fmiChar introduced.
+   - Feb.  17, 2013: Changed fmiTypesPlatform from "standard32" to "default".
+                     Removed fmiUndefinedValueReference since no longer needed
+                     (because every state is defined in ScalarVariables).
+   - March 20, 2012: Renamed from fmiPlatformTypes.h to fmiTypesPlatform.h
+   - Nov.  14, 2011: Use the header file "fmiPlatformTypes.h" for FMI 2.0
+                     both for "FMI for model exchange" and for "FMI for co-simulation"
+                     New types "fmiComponentEnvironment", "fmiState", and "fmiByte".
+                     The implementation of "fmiBoolean" is change from "char" to "int".
+                     The #define "fmiPlatform" changed to "fmiTypesPlatform"
+                     (in order that #define and function call are consistent)
+   - Oct.   4, 2010: Renamed header file from "fmiModelTypes.h" to fmiPlatformTypes.h"
+                     for the co-simulation interface
+   - Jan.   4, 2010: Renamed meModelTypes_h to fmiModelTypes_h (by Mauss, QTronic)
+   - Dec.  21, 2009: Changed "me" to "fmi" and "meModel" to "fmiComponent"
+                     according to meeting on Dec. 18 (by Martin Otter, DLR)
+   - Dec.   6, 2009: Added meUndefinedValueReference (by Martin Otter, DLR)
+   - Sept.  9, 2009: Changes according to FMI-meeting on July 21:
+                     Changed "version" to "platform", "standard" to "standard32",
+                     Added a precise definition of "standard32" as comment
+                     (by Martin Otter, DLR)
+   - July  19, 2009: Added "me" as prefix to file names, added meTrue/meFalse,
+                     and changed meValueReferenced from int to unsigned int
+                     (by Martin Otter, DLR).
+   - March  2, 2009: Moved enums and function pointer definitions to
+                     ModelFunctions.h (by Martin Otter, DLR).
+   - Dec.  3, 2008 : First version by Martin Otter (DLR) and
+                     Hans Olsson (Dynasim).
+
+
+   Copyright © 2008-2011 MODELISAR consortium,
+               2012-2013 Modelica Association Project "FMI"
+               All rights reserved.
+   This file is licensed by the copyright holders under the BSD 2-Clause License
+   (http://www.opensource.org/licenses/bsd-license.html):
+
+   ----------------------------------------------------------------------------
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the copyright holders nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+   OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   ----------------------------------------------------------------------------
+
+   with the extension:
+
+   You may distribute or publicly perform any modification only under the
+   terms of this license.
+   (Note, this means that if you distribute a modified file,
+    the modified file must also be provided under this license).
+*/
+
+/* Platform (unique identification of this header file) */
+#define fmi2TypesPlatform "default"
+
+/* Type definitions of variables passed as arguments
+   Version "default" means:
+
+   fmi2Component           : an opaque object pointer
+   fmi2ComponentEnvironment: an opaque object pointer
+   fmi2FMUstate            : an opaque object pointer
+   fmi2ValueReference      : handle to the value of a variable
+   fmi2Real                : double precision floating-point data type
+   fmi2Integer             : basic signed integer data type
+   fmi2Boolean             : basic signed integer data type
+   fmi2Char                : character data type
+   fmi2String              : a pointer to a vector of fmi2Char characters
+                             ('\0' terminated, UTF8 encoded)
+   fmi2Byte                : smallest addressable unit of the machine, typically one byte.
+*/
+   typedef void*           fmi2Component;               /* Pointer to FMU instance       */
+   typedef void*           fmi2ComponentEnvironment;    /* Pointer to FMU environment    */
+   typedef void*           fmi2FMUstate;                /* Pointer to internal FMU state */
+   typedef unsigned int    fmi2ValueReference;
+   typedef double          fmi2Real   ;
+   typedef int             fmi2Integer;
+   typedef int             fmi2Boolean;
+   typedef char            fmi2Char;
+   typedef const fmi2Char* fmi2String;
+   typedef char            fmi2Byte;
+
+/* Values for fmi2Boolean  */
+#define fmi2True  1
+#define fmi2False 0
+
+
+#endif /* fmi2TypesPlatform_h */


### PR DESCRIPTION
This merges the initial dummy example code (resolves #2), now refactored for current OSI draft and CMake build system. Builds on Win32/64 and Linux64 (and likely more platforms). Note that the OSI repo is currently referenced to the feature/initial-build-system branch prior to its merging (will be updated accordingly).

Ideally with installed protobufs a simple git clone, git submodule init, git submodule update and cmake call against the examples directory should properly build the sample FMU.

More build documentation to be added later.