### PR TITLE
Feature/add travis ci support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
     # Install a recent version of the Protobuf
     - |
-        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz"
+        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-2.6.1.tar.gz"
         mkdir -p protobuf
         travis_retry wget --no-check-certificate --quiet -O - ${PROTOBUF_URL} | tar --strip-components=1 -xz -C protobuf
         cd protobuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+# Source: https://github.com/boostorg/hana/blob/master/.travis.yml
+
+# Sudo is required for installing recent versions of dependencies.
+sudo: required
+
+# Use C++ build environment.
+language: cpp
+
+# Protobuf requires g++ (see https://github.com/google/protobuf/blob/master/src/README.md)
+compiler:
+    - gcc
+
+# Cache dependencies to speed up the build.
+cache:
+    directories:
+        - ${TRAVIS_BUILD_DIR}/deps/cmake
+        - ${TRAVIS_BUILD_DIR}/deps/protobuf
+
+# Handle dependencies in separate directory.
+before_install:
+    - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+    - mkdir -p "${DEPS_DIR}"
+    - cd "${DEPS_DIR}"
+
+install:
+    # Install a recent version of CMake
+    - |
+        CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz"
+        mkdir -p cmake
+        travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+
+    # Install a recent version of the Protobuf
+    - |
+        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-3.2.0.tar.gz"
+        mkdir -p protobuf
+        travis_retry wget --no-check-certificate --quiet -O - ${PROTOBUF_URL} | tar --strip-components=1 -xz -C protobuf
+        cd protobuf
+        ./configure --prefix=/usr
+        make
+        sudo make install
+
+# Change directory back to default build directory.
+before_script:
+    - cd "${TRAVIS_BUILD_DIR}/examples"
+
+# Run the build script.
+script:
+    - mkdir -p build
+    - cd build
+    - cmake ..
+    - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
     # Install a recent version of the Protobuf
     - |
-        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v3.2.0/protobuf-cpp-2.6.1.tar.gz"
+        PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
         mkdir -p protobuf
         travis_retry wget --no-check-certificate --quiet -O - ${PROTOBUF_URL} | tar --strip-components=1 -xz -C protobuf
         cd protobuf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 OSI Sensor Model Packaging
 ==========================
 
+[![Build Status](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging.svg?branch=master)](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging)
+
 This document specifies the ways in which sensor models are to be
 packaged for use in simulation environments using FMI 2.0.
 


### PR DESCRIPTION
Added travis ci support patterned on OSI repository (we use 2.6.1 protobufs since they are the baseline and 3.2.0 fails in build on travis ci image probably due to oldish gcc).