### PR TITLE
Bump version to 0.2.0, use semver, add osi-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ This document specifies the ways in which sensor models using the
 [Open Simulation Interface][] are to be packaged for use in simulation
 environments using FMI 2.0.
 
-This is version 0.1 Draft of this document.
+This is version 0.2.0 Draft of this document. The version number is
+to be interpreted according to the [Semantic Versioning Specification
+(SemVer) 2.0.0][SemVer2.0.0].
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in [RFC 2119][].
 
 [Open Simulation Interface]: https://github.com/OpenSimulationInterface/open-simulation-interface
+[SemVer2.0.0]: http://semver.org/spec/v2.0.0.html
 [RFC 2119]: https://www.ietf.org/rfc/rfc2119.txt
 
 ## FMI 2.0
@@ -35,8 +38,15 @@ The following basic conventions apply:
     into the `VendorAnnotations` element of the `modelDescription.xml`:
 
     ```XML
-    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="0.1"/></Tool>
+    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="0.2.0" osi-version="2.0.0"/></Tool>
     ```
+
+    where osi-version MUST contain the major, minor and patch
+    version number of the open simulation interface specification
+    that this model was compiled against.  This is to ensure that
+    the importing environment can determine which OSI version to
+    use prior to communicating with the FMU, which might be
+    impossible in cases of major version changes.
 
 -   The variable naming convention of the FMU MUST be `structured`.
 

--- a/examples/OSMPDummySensor/modelDescription.xml
+++ b/examples/OSMPDummySensor/modelDescription.xml
@@ -15,7 +15,7 @@
     canNotUseMemoryManagementFunctions="true"/>
   <DefaultExperiment startTime="0.0" stepSize="0.020"/>
   <VendorAnnotations>
-    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="0.1"/></Tool>
+    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="0.2.0" osi-version="2.0.0"/></Tool>
   </VendorAnnotations>
   <ModelVariables>
     <ScalarVariable name="OSMPSensorDataIn.base.lo" valueReference="0" causality="input" variability="discrete">


### PR DESCRIPTION
Use semantic versioning and bump version number to 0.2.0 prior to
freeze, add osi-version attribute to indicate OSI version so that
importing environments can switch between OSI implementations
prior to communicating with the FMU, which might be impossible if
the OSI major release has changed (e.g. if we switch to FlatBuffers,
or something else).