### PR TITLE
Feature/updated dummy sensor

### DIFF
--- a/examples/OSMPDummySensor/OSMPDummySensor.cpp
+++ b/examples/OSMPDummySensor/OSMPDummySensor.cpp
@@ -183,7 +183,7 @@ fmi2Status COSMPDummySensor::doCalc(fmi2Real currentCommunicationPoint, fmi2Real
     double time = currentCommunicationPoint+communicationStepSize;
     if (fmi_source()) {
         /* We act as GroundTruth Source, so ignore inputs */
-        static double y_offsets[10] = { -3.0, -3.0, -3.0, -0.5, 0, 0.5, 3.0, 3.0, 3.0, 3.0 };
+        static double y_offsets[10] = { 3.0, 3.0, 3.0, 0.5, 0, -0.5, -3.0, -3.0, -3.0, -3.0 };
         static double x_offsets[10] = { 0.0, 40.0, 100.0, 100.0, 0.0, 150.0, 5.0, 45.0, 85.0, 125.0 };
         static double x_speeds[10] = { 29.0, 30.0, 31.0, 25.0, 26.0, 28.0, 20.0, 22.0, 22.5, 23.0 };
         currentOut.Clear();

--- a/examples/OSMPDummySensor/OSMPDummySensor.cpp
+++ b/examples/OSMPDummySensor/OSMPDummySensor.cpp
@@ -181,6 +181,7 @@ fmi2Status COSMPDummySensor::doCalc(fmi2Real currentCommunicationPoint, fmi2Real
     DEBUGBREAK();
     osi::SensorData currentIn,currentOut;
     double time = currentCommunicationPoint+communicationStepSize;
+    normal_log("OSI","Calculating Sensor at %f for %f (step size %f)",currentCommunicationPoint,time,communicationStepSize);
     if (fmi_source()) {
         /* We act as GroundTruth Source, so ignore inputs */
         static double y_offsets[10] = { 3.0, 3.0, 3.0, 0.5, 0, -0.5, -3.0, -3.0, -3.0, -3.0 };
@@ -289,6 +290,7 @@ fmi2Status COSMPDummySensor::doCalc(fmi2Real currentCommunicationPoint, fmi2Real
         set_fmi_count(currentOut.object_size());
     } else {
         /* We have no valid input, so no valid output */
+        normal_log("OSI","No valid input, therefore providing no valid output.");
         reset_fmi_sensor_data_out();
         set_fmi_valid(false);
         set_fmi_count(0);


### PR DESCRIPTION
This updates the dummy sensor functionality to be better in line with current OSI intended usage, i.e. the source mode generates ground truth only, and the non-source mode transforms ground truth to sensor data detected objects.

Note that this feature branch is based on the improved-cmake-builds feature branch.