### PR TITLE
Feature/network proxy passive

### DIFF
--- a/examples/OSMPCNetworkProxy/CMakeLists.txt
+++ b/examples/OSMPCNetworkProxy/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 set(VERBOSE_FMI_LOGGING OFF CACHE BOOL "Enable detailed FMI function logging")
 set(FMU_DEFAULT_ADDRESS "127.0.0.1" CACHE STRING "Default address for connections")
 set(FMU_DEFAULT_PORT "3456" CACHE STRING "Default port for connections")
+set(FMU_LISTEN OFF CACHE BOOL "Create FMU that passively listens (server mode)")
 
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)
@@ -29,6 +30,7 @@ if(PRIVATE_LOGGING)
 		"PRIVATE_LOG_PATH=\"${PRIVATE_LOG_PATH_CPROXY_ESCAPED}\"")
 endif()
 target_compile_definitions(OSMPCNetworkProxy PRIVATE
+    $<$<BOOL:${FMU_LISTEN}>:FMU_LISTEN>
 	$<$<BOOL:${PUBLIC_LOGGING}>:PUBLIC_LOGGING>
 	$<$<BOOL:${VERBOSE_FMI_LOGGING}>:VERBOSE_FMI_LOGGING>)
 if(WIN32)

--- a/examples/OSMPCNetworkProxy/OSMPCNetworkProxy.h
+++ b/examples/OSMPCNetworkProxy/OSMPCNetworkProxy.h
@@ -125,6 +125,9 @@ typedef struct OSMPCNetworkProxy {
     double last_time;
 
     /* Proxy Connections */
+    #ifdef FMU_LISTEN
+    SOCKET tcp_proxy_listen_socket;
+    #endif
     SOCKET tcp_proxy_socket;
 
     /* Buffering */

--- a/examples/OSMPDummySensor/OSMPDummySensor.cpp
+++ b/examples/OSMPDummySensor/OSMPDummySensor.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <algorithm>
 #include <cstdint>
+#include <cmath>
 
 using namespace std;
 

--- a/examples/OSMPDummySensor10/OSMPDummySensor10.cpp
+++ b/examples/OSMPDummySensor10/OSMPDummySensor10.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <algorithm>
 #include <cstdint>
+#include <cmath>
 
 using namespace std;
 


### PR DESCRIPTION
This adds optional code to the OSMPCNetworkProxy that will listen to a connection rather than establishing a connection via connect. Can be enabled with the CMake FMU_LISTEN option, which defaults to false. Please be aware: This code has not been tested in operation, and is likely to place somewhat of a burden on simulation environments, since it can lead to unlimitted blocking while waiting for connection establishment.