### PR TITLE
Add auto-configuration to OSMPDummySensor example

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "default": true,
+    "MD003": { "style": "atx" },
+    "MD007": { "indent": 4 },
+    "MD013": false,
+    "MD030": { "ol_multi": 3, "ul_multi": 3 }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-OSI Sensor Model Packaging
-==========================
+# OSI Sensor Model Packaging
 
 [![Build Status](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging.svg?branch=master)](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging)
 
@@ -362,26 +361,21 @@ model FMU with one input and output and no additional features:
 </fmiModelDescription>
 ```
 
-## TODOs
-
--   Support various raw data streams, like e.g. video streams, or raw
-    reflection lists, in the same vein as the current object list
-    sensor data.  This is likely to be achieved using the same
-    basic mechanism, but including a string constant per input/output
-    indicating the MIME type of the transported data (or some other
-    naming scheme for the type), so that the variables can be
-    identified properly.  Can be merged with the above mechanism for
-    auto configuration, if employed.
-
 ## Future Evolution
 
-In the future an extension to the FMI standard that directly
-supported opaque binary data (e.g. a binary data type that
-is defined in the same way as the current string data type,
-but length terminated instead of zero-terminated) would allow
-migration of sensor models using the current convention to
-one where the sensor data input and output variables could be
-mapped into just one such input and output variable each, of
-the relevant binary type.  The object lifetimes might need to
-be adjusted in such a case to match the FMI standard extension,
-depending on the form that is going to take.
+For FMI 3.0, which is currently in development, an opaque
+binary data type (a binary data type that is defined in the
+same way as the current string data type, but length terminated
+instead of zero-terminated) is planned to be added.  This will
+allow migration of sensor models using the current convention to
+one where the relevant OSMP binary variables will be directly
+mapped to such new binary variables, instead of relying on the
+annotated trio of integer variables for each notional binary
+variable as is currently specified.  The life-time of the new
+FMI 3.0 variables will be the standard life-time of all FMI
+variables, and thus shorter than is currently specified, so
+copying on input and output is going to be required.  Other
+than that the current specification can be mapped 1:1 onto this
+new mechanism, and once FMI 3.0 is released, an updated OSMP
+specification including this option and mapping will be
+released.

--- a/examples/OSMPDummySensor/OSMPDummySensor.h
+++ b/examples/OSMPDummySensor/OSMPDummySensor.h
@@ -53,12 +53,19 @@ using namespace std;
 #define FMI_INTEGER_SENSORDATA_OUT_BASELO_IDX 3
 #define FMI_INTEGER_SENSORDATA_OUT_BASEHI_IDX 4
 #define FMI_INTEGER_SENSORDATA_OUT_SIZE_IDX 5
-#define FMI_INTEGER_COUNT_IDX 6
+#define FMI_INTEGER_SENSORVIEW_CONFIG_REQUEST_BASELO_IDX 6
+#define FMI_INTEGER_SENSORVIEW_CONFIG_REQUEST_BASEHI_IDX 7
+#define FMI_INTEGER_SENSORVIEW_CONFIG_REQUEST_SIZE_IDX 8
+#define FMI_INTEGER_SENSORVIEW_CONFIG_BASELO_IDX 9
+#define FMI_INTEGER_SENSORVIEW_CONFIG_BASEHI_IDX 10
+#define FMI_INTEGER_SENSORVIEW_CONFIG_SIZE_IDX 11
+#define FMI_INTEGER_COUNT_IDX 12
 #define FMI_INTEGER_LAST_IDX FMI_INTEGER_COUNT_IDX
 #define FMI_INTEGER_VARS (FMI_INTEGER_LAST_IDX+1)
 
 /* Real Variables */
-#define FMI_REAL_LAST_IDX 0
+#define FMI_REAL_NOMINAL_RANGE_IDX 0
+#define FMI_REAL_LAST_IDX FMI_REAL_NOMINAL_RANGE_IDX
 #define FMI_REAL_VARS (FMI_REAL_LAST_IDX+1)
 
 /* String Variables */
@@ -194,18 +201,29 @@ protected:
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
     string string_vars[FMI_STRING_VARS];
-    double last_time;
-    string currentBuffer;
-    string lastBuffer;
+    bool simulation_started;
+    string currentOutputBuffer;
+    string lastOutputBuffer;
+    string currentConfigRequestBuffer;
+    string lastConfigRequestBuffer;
 
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }
     void set_fmi_valid(fmi2Boolean value) { boolean_vars[FMI_BOOLEAN_VALID_IDX]=value; }
     fmi2Integer fmi_count() { return integer_vars[FMI_INTEGER_COUNT_IDX]; }
     void set_fmi_count(fmi2Integer value) { integer_vars[FMI_INTEGER_COUNT_IDX]=value; }
+    fmi2Real fmi_nominal_range() { return real_vars[FMI_REAL_NOMINAL_RANGE_IDX]; }
+    void set_fmi_nominal_range(fmi2Real value) { real_vars[FMI_REAL_NOMINAL_RANGE_IDX]=value; }
 
+    
     /* Protocol Buffer Accessors */
+    bool get_fmi_sensor_view_config(osi3::SensorViewConfiguration& data);
+    void set_fmi_sensor_view_config_request(const osi3::SensorViewConfiguration& data);
+    void reset_fmi_sensor_view_config_request();
     bool get_fmi_sensor_view_in(osi3::SensorView& data);
     void set_fmi_sensor_data_out(const osi3::SensorData& data);
     void reset_fmi_sensor_data_out();
+
+    /* Refreshing of Calculated Parameters */
+    void refresh_fmi_sensor_view_config_request();
 };

--- a/examples/OSMPDummySensor/modelDescription.in.xml
+++ b/examples/OSMPDummySensor/modelDescription.in.xml
@@ -63,11 +63,50 @@
         <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorDataOut" role="size" mime-type="application/x-open-simulation-interface; type=SensorData; version=3.0.0"/></Tool>
       </Annotations>
     </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfigRequest.base.lo" valueReference="6" causality="calculatedParameter" variability="fixed" initial="calculated">
+      <Integer/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfigRequest" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfigRequest.base.hi" valueReference="7" causality="calculatedParameter" variability="fixed" initial="calculated">
+      <Integer/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfigRequest" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfigRequest.size" valueReference="8" causality="calculatedParameter" variability="fixed" initial="calculated">
+      <Integer/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfigRequest" role="size" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfig.base.lo" valueReference="9" causality="parameter" variability="fixed">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfig" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfig.base.hi" valueReference="10" causality="parameter" variability="fixed">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfig" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
+    <ScalarVariable name="OSMPSensorViewInConfig.size" valueReference="11" causality="parameter" variability="fixed">
+      <Integer start="0"/>
+      <Annotations>
+        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewInConfig" role="size" mime-type="application/x-open-simulation-interface; type=SensorViewConfiguration; version=3.0.0"/></Tool>
+      </Annotations>
+    </ScalarVariable>
     <ScalarVariable name="valid" valueReference="0" causality="output" variability="discrete" initial="exact">
       <Boolean start="false"/>
     </ScalarVariable>
-    <ScalarVariable name="count" valueReference="6" causality="output" variability="discrete" initial="exact">
+    <ScalarVariable name="count" valueReference="12" causality="output" variability="discrete" initial="exact">
       <Integer start="0"/>
+    </ScalarVariable>
+    <ScalarVariable name="nominalrange" valueReference="0" causality="parameter" variability="fixed">
+      <Real start="135.0"/>
     </ScalarVariable>
   </ModelVariables>
   <ModelStructure>
@@ -75,8 +114,13 @@
       <Unknown index="4"/>
       <Unknown index="5"/>
       <Unknown index="6"/>
-      <Unknown index="7"/>
-      <Unknown index="8"/>
+      <Unknown index="13"/>
+      <Unknown index="14"/>
     </Outputs>
+    <InitialUnknowns>
+      <Unknown index="7" dependencies="10 11 12 15"/>
+      <Unknown index="8" dependencies="10 11 12 15"/>
+      <Unknown index="9" dependencies="10 11 12 15"/>
+    </InitialUnknowns>
   </ModelStructure>
 </fmiModelDescription>

--- a/examples/OSMPDummySource/OSMPDummySource.cpp
+++ b/examples/OSMPDummySource/OSMPDummySource.cpp
@@ -146,17 +146,21 @@ fmi2Status COSMPDummySource::doInit()
 fmi2Status COSMPDummySource::doStart(fmi2Boolean toleranceDefined, fmi2Real tolerance, fmi2Real startTime, fmi2Boolean stopTimeDefined, fmi2Real stopTime)
 {
     DEBUGBREAK();
-    last_time = startTime;
+
     return fmi2OK;
 }
 
 fmi2Status COSMPDummySource::doEnterInitializationMode()
 {
+    DEBUGBREAK();
+
     return fmi2OK;
 }
 
 fmi2Status COSMPDummySource::doExitInitializationMode()
 {
+    DEBUGBREAK();
+
     return fmi2OK;
 }
 
@@ -182,6 +186,7 @@ void rotatePoint(double x, double y, double z,double yaw,double pitch,double rol
 fmi2Status COSMPDummySource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPointfmi2Component)
 {
     DEBUGBREAK();
+
     osi3::SensorView currentOut;
     double time = currentCommunicationPoint+communicationStepSize;
 
@@ -242,7 +247,7 @@ fmi2Status COSMPDummySource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real
         veh->mutable_base()->mutable_orientation_rate()->set_pitch(0.0);
         veh->mutable_base()->mutable_orientation_rate()->set_roll(0.0);
         veh->mutable_base()->mutable_orientation_rate()->set_yaw(0.0);
-        normal_log("OSI","GT: Adding Vehicle %d[%d] Absolute Position: %f,%f,%f Velocity (%f,%f,%f)",i,veh->id().value(),veh->base().position().x(),veh->base().position().y(),veh->base().position().z(),veh->base().velocity().x(),veh->base().velocity().y(),veh->base().velocity().z());
+        normal_log("OSI","GT: Adding Vehicle %d[%llu] Absolute Position: %f,%f,%f Velocity (%f,%f,%f)",i,veh->id().value(),veh->base().position().x(),veh->base().position().y(),veh->base().position().z(),veh->base().velocity().x(),veh->base().velocity().y(),veh->base().velocity().z());
     }
 
     set_fmi_sensor_view_out(currentOut);
@@ -273,8 +278,7 @@ COSMPDummySource::COSMPDummySource(fmi2String theinstanceName, fmi2Type thefmuTy
     fmuResourceLocation(thefmuResourceLocation),
     functions(*thefunctions),
     visible(!!thevisible),
-    loggingOn(!!theloggingOn),
-    last_time(0.0)
+    loggingOn(!!theloggingOn)
 {
     loggingCategories.clear();
     loggingCategories.insert("FMI");

--- a/examples/OSMPDummySource/OSMPDummySource.h
+++ b/examples/OSMPDummySource/OSMPDummySource.h
@@ -190,7 +190,6 @@ protected:
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
     string string_vars[FMI_STRING_VARS];
-    double last_time;
     string currentBuffer;
     string lastBuffer;
 


### PR DESCRIPTION
This PR finalizes the spec (minor cleanups), and adds auto-configuration via SensorViewConfiguration to the OSMPDummySensor example code base, among minor code cleanups. Fixes #37.