### PR TITLE
Fix docs and spec references, build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 [![Build Status](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging.svg?branch=master)](https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging)
 
-OSI Sensor Model Packaging specifies ways in which environmental effect models, sensor models and logical models using the [Open Simulation Interface (OSI)][] are to be packaged for their use in simulation environments using FMI 2.0. For more detailed information see the [official documentation](https://opensimulationinterface.github.io/osi-documentation/osi-sensor-model-packaging/README.html).
+OSI Sensor Model Packaging specifies ways in which models (like e.g. environmental effect models, sensor models and logical models) using the [Open Simulation Interface (OSI)][] are to be packaged for their use in simulation environments using FMI 2.0.
+The specification can be found in the [doc/specification.rst](doc/specification.rst) document in this repository.
+
+For more detailed information see the [official documentation](https://opensimulationinterface.github.io/osi-documentation/osi-sensor-model-packaging/README.html).
 
 [Open Simulation Interface (OSI)]: https://github.com/OpenSimulationInterface/open-simulation-interface
 
@@ -13,69 +16,7 @@ The [`OSMPDummySource`](https://github.com/OpenSimulationInterface/osi-sensor-mo
 
 The [`OSMPCNetworkProxy`](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPCNetworkProxy) example demonstrates a simple C network proxy that can send and receive OSI data via TCP sockets.
 
-The [`OSMPDummySensor`](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPDummySensor) example can be used as a simple dummy sensor model, demonstrating the use of OSI for sensor models consuming SensorView data and generating SensorData output. Below you can find an example `modelDescription.xml` file that would satisfy the requirements of this document for a sensor model FMU with one input and output and no additional features:
-
-```XML
-<?xml version="1.0" encoding="UTF-8"?>
-<fmiModelDescription
-  fmiVersion="2.0"
-  modelName="OSI Sensor Model Packaging Demo FMU"
-  guid="aabc2174e20f08597cfae6947c96bf86"
-  variableNamingConvention="structured">
-  <CoSimulation
-    modelIdentifier="OSMPDemoFMU"
-    canNotUseMemoryManagementFunctions="true"/>
-  <DefaultExperiment startTime="0.0" stepSize="0.020"/>
-  <VendorAnnotations>
-    <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp version="1.0.0" osi-version="3.0.0"/></Tool>
-  </VendorAnnotations>
-  <ModelVariables>
-    <ScalarVariable name="OSMPSensorViewIn.base.lo" valueReference="0" causality="input" variability="discrete">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewIn" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorView; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-    <ScalarVariable name="OSMPSensorViewIn.base.hi" valueReference="1" causality="input" variability="discrete">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewIn" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorView; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-    <ScalarVariable name="OSMPSensorViewIn.size" valueReference="2" causality="input" variability="discrete">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorViewIn" role="size" mime-type="application/x-open-simulation-interface; type=SensorView; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.base.lo" valueReference="3" causality="output" variability="discrete" initial="exact">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorDataOut" role="base.lo" mime-type="application/x-open-simulation-interface; type=SensorData; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.base.hi" valueReference="4" causality="output" variability="discrete" initial="exact">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorDataOut" role="base.hi" mime-type="application/x-open-simulation-interface; type=SensorData; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-    <ScalarVariable name="OSMPSensorDataOut.size" valueReference="5" causality="output" variability="discrete" initial="exact">
-      <Integer start="0"/>
-      <Annotations>
-        <Tool name="net.pmsf.osmp" xmlns:osmp="http://xsd.pmsf.net/OSISensorModelPackaging"><osmp:osmp-binary-variable name="OSMPSensorDataOut" role="size" mime-type="application/x-open-simulation-interface; type=SensorData; version=3.0.0"/></Tool>
-      </Annotations>
-    </ScalarVariable>
-  </ModelVariables>
-  <ModelStructure>
-    <Outputs>
-      <Unknown index="4"/>
-      <Unknown index="5"/>
-      <Unknown index="6"/>
-    </Outputs>
-  </ModelStructure>
-</fmiModelDescription>
-```
+The [`OSMPDummySensor`](https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/tree/master/examples/OSMPDummySensor) example can be used as a simple dummy sensor model, demonstrating the use of OSI for sensor models consuming SensorView data and generating SensorData output.
 
 ## Installation
 ##### Dependencies
@@ -92,8 +33,9 @@ $ sudo apt-get install libprotobuf-dev protobuf-compiler
 ##### Build and install example
 ```bash
 $ git clone https://github.com/OpenSimulationInterface/osi-sensor-model-packaging.git
-$ cd osi-sensor-model-packaging/examples
-$ git clone https://github.com/OpenSimulationInterface/open-simulation-interface.git
+$ cd osi-sensor-model-packaging
+$ git submodule update --init
+$ cd examples
 $ mkdir -p build
 $ cd build
 $ cmake ..

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -1,5 +1,5 @@
-General Description
-==========================
+OSI Sensor Model Packaging Specification
+========================================
 
 This document specifies the ways in which environmental effect models,
 sensor models and logical models using the `Open Simulation Interface`_
@@ -469,6 +469,3 @@ released.
 .. _RFC 2119: https://www.ietf.org/rfc/rfc2119.txt
 .. _FMI: https://fmi-standard.org/
 .. _FMI 2.0 standard: https://svn.modelica.org/fmi/branches/public/specifications/v2.0/FMI_for_ModelExchange_and_CoSimulation_v2.0.pdf
-
-.. |Build Status| image:: https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging.svg?branch=master
-   :target: https://travis-ci.org/OpenSimulationInterface/osi-sensor-model-packaging


### PR DESCRIPTION
#### Add a description
This PR makes the OSMP specification document, which is the actual content of the OSMP project more prominently visible and accessible, counteracting the unhealthy focus on the examples (which could be dropped any minute); also fixes the build instructions (OSI is a submodule, no need to clone it, which would break the version dependencies) and removes the XML crud from the README. Note that since the specification document is renamed to indicate that it is the specification, not some generic description, that the related PR in osi-documentation is needed to keep this in sync.

#### Check the checklist

- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests / travis ci pass locally with my changes.