### PR TITLE
Introduce OSI Traffic Participants

### DIFF
--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -388,8 +388,6 @@ Traffic Participant Initialization
 ----------------------------------
 
 - Traffic Participant models consume at least one initialization parameter.
-  The initialization parameters MUST be set by the environment before calling
-  ``fmi2EnterInitializationMode``.
 
 - The first parameter MUST be named ``OSMPGroundTruthInit``. Its purpose is to
   provide the Traffic Participant model with a view of the static environment,
@@ -400,7 +398,7 @@ Traffic Participant Initialization
    ``variability="fixed"`` and ``initial="exact"``.
 
 -  The MIME type of the variable MUST specify the ``type=GroundTruth``, e.g.
-   ``application/x-open-simulation-interface; type=GroundTruth; version=3.0.0``.
+   ``application/x-open-simulation-interface; type=GroundTruth; version=3.2.0``.
 
 - ``OSMPGroundTruthInit`` MUST be encoded as ``osi::GroundTruth`` (see the OSI
   specification documentation for more details).
@@ -412,16 +410,16 @@ Traffic Participant Initialization
 - The Ids of objects in ``OSMPGroundTruthInit`` MUST be identical to the Ids of
   the same objects contained in later ``OSMPSensorDataIn`` objects.
 
-- If the model is instantiated multiple times, then all instantiations MUST
+- If the model is instantiated multiple times, then all instantiations SHOULD
   receive the exact same content stored in the ``OSMPGroundTruthInit``
   parameter. This allows a model to do expensive map calculations only once
   during initialization, and to share the calculated data between multiple
   instantiations.
 
--  The guaranteed lifetime of the ground truh protocol buffer pointer
+-  The guaranteed lifetime of the ground truth protocol buffer pointer
    provided as input to the FMU MUST be from the time of the call to
-   ``fmi2SetInteger`` that provides those values until the end of the
-   simulation.
+   ``fmi2SetInteger`` that provides those values until the end of the following
+   ``fmi2ExitInitializationMode`` call.
 
 Traffic Update Outputs
 ----------------------

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -36,8 +36,8 @@ can be packaged as FMUs:
    implement surrounding traffic in simplified ways.  Optionally traffic
    participant models can consume ``osi::TrafficCommand`` as input, to
    allow control by a scenario engine as part of the simulation.
-   Traffic Participant models consume a global ``osi::GroundTruth`` during
-   initialization.
+   Traffic Participant models can consume a global ``osi::GroundTruth``
+   during initialization.
 
 Additionally complex models that combine various aspects of the model
 kinds above are possible, however configuration and setup of such FMUs
@@ -387,11 +387,13 @@ Sensor Data Inputs
 Traffic Participant Initialization
 ----------------------------------
 
-- Traffic Participant models consume at least one initialization parameter.
+- Traffic Participant models CAN consume an ``osi::GroundTruth`` as an
+  initialization parameter.
 
-- The first parameter MUST be named ``OSMPGroundTruthInit``. Its purpose is to
-  provide the Traffic Participant model with a view of the static environment,
-  in the OSI format.
+- If the traffic participant needs a ground truth during initialization, it
+  MUST have a parameter named ``OSMPGroundTruthInit``. Its purpose is to
+  provide the Traffic Participant model with a view of the static environment
+  (i.e. the map), in the OSI format.
 
 -  ``OSMPGroundTruthInit`` MUST be defined as a notional discrete binary
    input variable, as specified above, with ``causality="parameter"``,
@@ -408,7 +410,7 @@ Traffic Participant Initialization
   (e.g. vehicles).
 
 - The Ids of objects in ``OSMPGroundTruthInit`` MUST be identical to the Ids of
-  the same objects contained in later ``OSMPSensorDataIn`` objects.
+  the same objects contained in later ``OSMPSensorViewIn`` input.
 
 - If the model is instantiated multiple times, then all instantiations SHOULD
   receive the exact same content stored in the ``OSMPGroundTruthInit``

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -406,8 +406,8 @@ Traffic Participant Initialization
   specification documentation for more details).
 
 - ``OSMPGroundTruthInit`` MUST contain all static data (e.g. roads) encountered
-  by the model during a simulation run. It MAY NOT contain any dynamic data
-  (e.g. vehicles).
+  by the model during a simulation run. Any dynamic data (e.g. MovingObjects)
+  it contains MUST NOT be used and has no specified semantics.
 
 - The Ids of objects in ``OSMPGroundTruthInit`` MUST be identical to the Ids of
   the same objects contained in later ``OSMPSensorViewIn`` input.

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -36,8 +36,9 @@ can be packaged as FMUs:
    implement surrounding traffic in simplified ways.  Optionally traffic
    participant models can consume ``osi::TrafficCommand`` as input, to
    allow control by a scenario engine as part of the simulation.
-   Traffic Participant models can consume a global ``osi::GroundTruth``
-   during initialization.
+
+All models can optionally also consume a global ``osi::GroundTruth``
+during initialization.
 
 Additionally complex models that combine various aspects of the model
 kinds above are possible, however configuration and setup of such FMUs
@@ -384,20 +385,20 @@ Sensor Data Inputs
    processes that generated the data, i.e. the exact details of the
    contents will depend on the processing pipeline.
 
-Traffic Participant Initialization
-----------------------------------
+GroundTruth Initialization Parameters
+-------------------------------------
 
-- Traffic Participant models CAN consume an ``osi::GroundTruth`` as an
+- All models CAN optionally consume an ``osi::GroundTruth`` as an
   initialization parameter.
 
-- If the traffic participant needs a ground truth during initialization, it
-  MUST have a parameter named ``OSMPGroundTruthInit``. Its purpose is to
-  provide the Traffic Participant model with a view of the static environment
-  (i.e. the map), in the OSI format.
+- If a model needs a ground truth during initialization, it MUST have
+  a parameter named ``OSMPGroundTruthInit``. Its purpose is to provide
+  the model with a view of the static environment (i.e. the map), in
+  OSI format.
 
 -  ``OSMPGroundTruthInit`` MUST be defined as a notional discrete binary
-   input variable, as specified above, with ``causality="parameter"``,
-   ``variability="fixed"`` and ``initial="exact"``.
+   input parameter variable, as specified above, with
+   ``causality="parameter"``, ``variability="fixed"`` and ``initial="exact"``.
 
 -  The MIME type of the variable MUST specify the ``type=GroundTruth``, e.g.
    ``application/x-open-simulation-interface; type=GroundTruth; version=3.2.0``.
@@ -410,7 +411,7 @@ Traffic Participant Initialization
   it contains MUST NOT be used and has no specified semantics.
 
 - The Ids of objects in ``OSMPGroundTruthInit`` MUST be identical to the Ids of
-  the same objects contained in later ``OSMPSensorViewIn`` input.
+  the same objects contained in later ``OSMPSensorViewIn`` or other input data.
 
 - If the model is instantiated multiple times, then all instantiations SHOULD
   receive the exact same content stored in the ``OSMPGroundTruthInit``

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -2,9 +2,9 @@ OSI Sensor Model Packaging Specification
 ========================================
 
 This document specifies the ways in which environmental effect models,
-sensor models and logical models using the `Open Simulation Interface`_
-are to be packaged for their use in simulation environments using FMI
-2.0.
+sensor models, logical models and traffic participant models using the
+`Open Simulation Interface`_ are to be packaged for their use in simulation 
+environments using FMI 2.0.
 
 This is version 1.1.0 of this document. The version number is to be
 interpreted according to the `Semantic Versioning Specification (SemVer)
@@ -24,7 +24,7 @@ can be packaged as FMUs:
    and produce ``osi::SensorView`` as output,
 
 -  Sensor models, which consume ``osi::SensorView`` as input and generate
-   ``osi::SensorData`` as output, and
+   ``osi::SensorData`` as output, 
 
 -  Logical models, like e.g. sensor fusion models, which consume
    ``osi::SensorData`` as input and produce ``osi::SensorData`` as output.
@@ -33,7 +33,7 @@ can be packaged as FMUs:
    and generate ``osi::TrafficUpdate`` as output.  These models can
    internally use e.g. Environmental effect, Sensor and/or Logical models
    as part of a modeled autonomous vehicle, but they can also be used to
-   implement surrounding traffic in simplified ways.  Optionally traffic
+   implement surrounding traffic in simplified ways.  Optionally, traffic
    participant models can consume ``osi::TrafficCommand`` as input, to
    allow control by a scenario engine as part of the simulation.
 
@@ -401,7 +401,7 @@ GroundTruth Initialization Parameters
    ``causality="parameter"``, ``variability="fixed"`` and ``initial="exact"``.
 
 -  The MIME type of the variable MUST specify the ``type=GroundTruth``, e.g.
-   ``application/x-open-simulation-interface; type=GroundTruth; version=3.2.0``.
+   ``application/x-open-simulation-interface; type=GroundTruth; version=3.3.0``.
 
 - ``OSMPGroundTruthInit`` MUST be encoded as ``osi::GroundTruth`` (see the OSI
   specification documentation for more details).
@@ -442,7 +442,7 @@ Traffic Update Outputs
 
 -  The MIME type of the variable MUST specify the ``type=TrafficUpdate``,
    e.g.
-   ``application/x-open-simulation-interface; type=TrafficUpdate; version=3.0.0``.
+   ``application/x-open-simulation-interface; type=TrafficUpdate; version=3.3.0``.
 
 -  The traffic update MUST be encoded as ``osi::TrafficUpdate`` (see the
    OSI specification documentation for more details).
@@ -486,7 +486,7 @@ Traffic Command Inputs
 
 -  The MIME type of the variable MUST specify the ``type=TrafficCommand``,
    e.g.
-   ``application/x-open-simulation-interface; type=TrafficCommand; version=3.0.0``.
+   ``application/x-open-simulation-interface; type=TrafficCommand; version=3.3.0``.
 
 -  The traffic command MUST be encoded as ``osi::TrafficCommand`` (see
    the OSI specification documentation for more details).

--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -36,6 +36,8 @@ can be packaged as FMUs:
    implement surrounding traffic in simplified ways.  Optionally traffic
    participant models can consume ``osi::TrafficCommand`` as input, to
    allow control by a scenario engine as part of the simulation.
+   Traffic Participant models consume a global ``osi::GroundTruth`` during
+   initialization.
 
 Additionally complex models that combine various aspects of the model
 kinds above are possible, however configuration and setup of such FMUs
@@ -381,6 +383,45 @@ Sensor Data Inputs
 -  The sensor data passed to the model depends on any prior models or
    processes that generated the data, i.e. the exact details of the
    contents will depend on the processing pipeline.
+
+Traffic Participant Initialization
+----------------------------------
+
+- Traffic Participant models consume at least one initialization parameter.
+  The initialization parameters MUST be set by the environment before calling
+  ``fmi2EnterInitializationMode``.
+
+- The first parameter MUST be named ``OSMPGroundTruthInit``. Its purpose is to
+  provide the Traffic Participant model with a view of the static environment,
+  in the OSI format.
+
+-  ``OSMPGroundTruthInit`` MUST be defined as a notional discrete binary
+   input variable, as specified above, with ``causality="parameter"``,
+   ``variability="fixed"`` and ``initial="exact"``.
+
+-  The MIME type of the variable MUST specify the ``type=GroundTruth``, e.g.
+   ``application/x-open-simulation-interface; type=GroundTruth; version=3.0.0``.
+
+- ``OSMPGroundTruthInit`` MUST be encoded as ``osi::GroundTruth`` (see the OSI
+  specification documentation for more details).
+
+- ``OSMPGroundTruthInit`` MUST contain all static data (e.g. roads) encountered
+  by the model during a simulation run. It MAY NOT contain any dynamic data
+  (e.g. vehicles).
+
+- The Ids of objects in ``OSMPGroundTruthInit`` MUST be identical to the Ids of
+  the same objects contained in later ``OSMPSensorDataIn`` objects.
+
+- If the model is instantiated multiple times, then all instantiations MUST
+  receive the exact same content stored in the ``OSMPGroundTruthInit``
+  parameter. This allows a model to do expensive map calculations only once
+  during initialization, and to share the calculated data between multiple
+  instantiations.
+
+-  The guaranteed lifetime of the ground truh protocol buffer pointer
+   provided as input to the FMU MUST be from the time of the call to
+   ``fmi2SetInteger`` that provides those values until the end of the
+   simulation.
 
 Traffic Update Outputs
 ----------------------


### PR DESCRIPTION
This PR is part of the SETLevel4To5 extensions of OSI and OSMP, introducing Traffic Participant as a model kind, as well as optionally separating out static content handling for planning and efficiency purposes:

* A new model kind of Traffic Participant is added, which has one or more SensorView inputs, an optional TrafficCommand input, and a TrafficUpdate output which is fed back into the simulation. The optional TrafficCommand input allows control of the traffic participant by e.g. a scenario engine.

* Optional GroundTruthInit parameters are introduced to all model kinds to allow receiving a complete set of static ground truth data prior to initialization start; this enables inter alia complex pre-processing to occur without endangering real-time performance.

   As a corollary a PR to add a flag to omit static ground truth content from SensorView to the SensorViewConfiguration message is created in OSI. In combination this approach allows the reduction of transferred data by eliminating redundant transfer of static content.

   It is currently on purpose left undefined, what exactly constitutes static content, since this definition should be done across OSI as a whole through the ASAM development process (i.e. to answer questions like: Are StationaryObjects static, even if they could be moved - e.g. traffic cones?, etc.).

The setup described by these changes is being used as mainbranch development platform for SETLevel4To5 model development.

It is being provided as a draft PR to aid in discussion of those changes in the relevant ASAM working packages. Additional changes from SETLevel4To5 might be pushed to the branch when released.

#### Check the checklist

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests / travis ci pass locally with my changes.