### PR TITLE
Make XML schema flexible about patch/minor releases

### DIFF
--- a/osmp.xsd
+++ b/osmp.xsd
@@ -5,7 +5,11 @@
     vc:minVersion="1.0" vc:maxVersion="1.1">
     <xs:element name="osmp">
         <xs:complexType>
-            <xs:attribute name="version" type="xs:string" use="required" fixed="1.1.0"/>
+            <xs:attribute name="version" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"><xs:pattern value="1[.][0-9][.][0-9]+"></xs:pattern></xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
             <xs:attribute name="osi-version" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
This enables us to release minor and patch releases, e.g. for
re-aligning with OSI patch releases, without breaking release
compatibility.  This matches the release semantics, where
structural changes in the XML description would require a major
release, whereas newly added inputs/outputs/parameters would not,
as long as they are optional.

Signed-off-by: Pierre R. Mai <pmai@pmsf.de>
