### PR TITLE
Make source FMUs compileable and carry config

### DIFF
--- a/examples/OSMPCNetworkProxy/CMakeLists.txt
+++ b/examples/OSMPCNetworkProxy/CMakeLists.txt
@@ -8,6 +8,10 @@ if(WIN32)
 else()
 	set(PRIVATE_LOG_PATH_CPROXY "/tmp/OSMPCNetworkProxyLog.log" CACHE FILEPATH "Path to write private log file to")
 endif()
+if(PRIVATE_LOGGING)
+	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH_CPROXY} PRIVATE_LOG_PATH_CPROXY_NATIVE)
+	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH ${PRIVATE_LOG_PATH_CPROXY_NATIVE})
+endif()
 set(VERBOSE_FMI_LOGGING OFF CACHE BOOL "Enable detailed FMI function logging")
 set(DEBUG_BREAKS OFF CACHE BOOL "Enable debugger traps for debug builds of FMU")
 set(FMU_DEFAULT_ADDRESS "127.0.0.1" CACHE STRING "Default address for connections")
@@ -17,27 +21,15 @@ set(FMU_LISTEN OFF CACHE BOOL "Create FMU that passively listens (server mode)")
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)
 configure_file(modelDescription.in.xml modelDescription.xml @ONLY)
+configure_file(OSMPCNetworkProxyConfig.in.h OSMPCNetworkProxyConfig.h)
 
 add_library(OSMPCNetworkProxy SHARED OSMPCNetworkProxy.c)
 set_target_properties(OSMPCNetworkProxy PROPERTIES PREFIX "")
 target_compile_definitions(OSMPCNetworkProxy PRIVATE "FMU_SHARED_OBJECT")
-target_compile_definitions(OSMPCNetworkProxy PRIVATE "FMU_GUID=\"${FMUGUID}\"")
-target_compile_definitions(OSMPCNetworkProxy PRIVATE "FMU_DEFAULT_ADDRESS=\"${FMU_DEFAULT_ADDRESS}\"")
-target_compile_definitions(OSMPCNetworkProxy PRIVATE "FMU_DEFAULT_PORT=\"${FMU_DEFAULT_PORT}\"")
-if(PRIVATE_LOGGING)
-	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH_CPROXY} PRIVATE_LOG_PATH_CPROXY_NATIVE)
-	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH_CPROXY_ESCAPED ${PRIVATE_LOG_PATH_CPROXY_NATIVE})
-	target_compile_definitions(OSMPCNetworkProxy PRIVATE
-		"PRIVATE_LOG_PATH=\"${PRIVATE_LOG_PATH_CPROXY_ESCAPED}\"")
-endif()
-target_compile_definitions(OSMPCNetworkProxy PRIVATE
-    $<$<BOOL:${FMU_LISTEN}>:FMU_LISTEN>
-	$<$<BOOL:${PUBLIC_LOGGING}>:PUBLIC_LOGGING>
-	$<$<BOOL:${VERBOSE_FMI_LOGGING}>:VERBOSE_FMI_LOGGING>
-	$<$<BOOL:${DEBUG_BREAKS}>:DEBUG_BREAKS>)
 if(WIN32)
 	target_link_libraries(OSMPCNetworkProxy wsock32 ws2_32)
 endif()
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(WIN32)
 	if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
@@ -67,5 +59,6 @@ add_custom_command(TARGET OSMPCNetworkProxy
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/modelDescription.xml"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPCNetworkProxy.c" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/OSMPCNetworkProxy.c"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPCNetworkProxy.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/OSMPCNetworkProxy.h"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/OSMPCNetworkProxyConfig.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/OSMPCNetworkProxyConfig.h"
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OSMPCNetworkProxy> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
 	COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "../OSMPCNetworkProxy.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/examples/OSMPCNetworkProxy/OSMPCNetworkProxy.h
+++ b/examples/OSMPCNetworkProxy/OSMPCNetworkProxy.h
@@ -8,6 +8,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "OSMPCNetworkProxyConfig.h"
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>

--- a/examples/OSMPCNetworkProxy/OSMPCNetworkProxyConfig.in.h
+++ b/examples/OSMPCNetworkProxy/OSMPCNetworkProxyConfig.in.h
@@ -1,0 +1,19 @@
+/*
+ * PMSF FMU Framework for FMI 2.0 Co-Simulation FMUs
+ *
+ * (C) 2016 -- 2018 PMSF IT Consulting Pierre R. Mai
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#cmakedefine PUBLIC_LOGGING
+#cmakedefine PRIVATE_LOG_PATH "@PRIVATE_LOG_PATH@"
+#cmakedefine VERBOSE_FMI_LOGGING
+#cmakedefine DEBUG_BREAKS
+#define FMU_GUID "@FMUGUID@"
+
+#cmakedefine FMU_LISTEN
+#define FMU_DEFAULT_ADDRESS "@FMU_DEFAULT_ADDRESS@"
+#define FMU_DEFAULT_PORT "@FMU_DEFAULT_PORT@"

--- a/examples/OSMPDummySensor/CMakeLists.txt
+++ b/examples/OSMPDummySensor/CMakeLists.txt
@@ -11,33 +11,28 @@ if(WIN32)
 else()
 	set(PRIVATE_LOG_PATH "/tmp/OSMPDummySensorLog.log" CACHE FILEPATH "Path to write private log file to")
 endif()
+if(PRIVATE_LOGGING)
+	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH} PRIVATE_LOG_PATH_NATIVE)
+	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH ${PRIVATE_LOG_PATH_NATIVE})
+endif()
 set(VERBOSE_FMI_LOGGING OFF CACHE BOOL "Enable detailed FMI function logging")
 set(DEBUG_BREAKS OFF CACHE BOOL "Enable debugger traps for debug builds of FMU")
 
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)
 configure_file(modelDescription.in.xml modelDescription.xml @ONLY)
+configure_file(OSMPDummySensorConfig.in.h OSMPDummySensorConfig.h)
 
 find_package(Protobuf 2.6.1 REQUIRED)
 add_library(OSMPDummySensor SHARED OSMPDummySensor.cpp)
 set_target_properties(OSMPDummySensor PROPERTIES PREFIX "")
 target_compile_definitions(OSMPDummySensor PRIVATE "FMU_SHARED_OBJECT")
-target_compile_definitions(OSMPDummySensor PRIVATE "FMU_GUID=\"${FMUGUID}\"")
 if(LINK_WITH_SHARED_OSI)
 	target_link_libraries(OSMPDummySensor open_simulation_interface)
 else()
 	target_link_libraries(OSMPDummySensor open_simulation_interface_pic)
 endif()
-if(PRIVATE_LOGGING)
-	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH} PRIVATE_LOG_PATH_NATIVE)
-	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH_ESCAPED ${PRIVATE_LOG_PATH_NATIVE})
-	target_compile_definitions(OSMPDummySensor PRIVATE
-		"PRIVATE_LOG_PATH=\"${PRIVATE_LOG_PATH_ESCAPED}\"")
-endif()
-target_compile_definitions(OSMPDummySensor PRIVATE
-	$<$<BOOL:${PUBLIC_LOGGING}>:PUBLIC_LOGGING>
-	$<$<BOOL:${VERBOSE_FMI_LOGGING}>:VERBOSE_FMI_LOGGING>
-	$<$<BOOL:${DEBUG_BREAKS}>:DEBUG_BREAKS>)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(WIN32)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -67,5 +62,6 @@ add_custom_command(TARGET OSMPDummySensor
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPDummySensor.cpp" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPDummySensor.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/OSMPDummySensorConfig.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/OSMPDummySensorConfig.h"
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OSMPDummySensor> $<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:OSMPDummySensor>>> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
 	COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "../OSMPDummySensor.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/examples/OSMPDummySensor/OSMPDummySensor.h
+++ b/examples/OSMPDummySensor/OSMPDummySensor.h
@@ -8,6 +8,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "OSMPDummySensorConfig.h"
+
 using namespace std;
 
 #ifndef FMU_SHARED_OBJECT

--- a/examples/OSMPDummySensor/OSMPDummySensorConfig.in.h
+++ b/examples/OSMPDummySensor/OSMPDummySensorConfig.in.h
@@ -1,0 +1,15 @@
+/*
+ * PMSF FMU Framework for FMI 2.0 Co-Simulation FMUs
+ *
+ * (C) 2016 -- 2018 PMSF IT Consulting Pierre R. Mai
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#cmakedefine PUBLIC_LOGGING
+#cmakedefine PRIVATE_LOG_PATH "@PRIVATE_LOG_PATH@"
+#cmakedefine VERBOSE_FMI_LOGGING
+#cmakedefine DEBUG_BREAKS
+#define FMU_GUID "@FMUGUID@"

--- a/examples/OSMPDummySource/CMakeLists.txt
+++ b/examples/OSMPDummySource/CMakeLists.txt
@@ -11,33 +11,28 @@ if(WIN32)
 else()
 	set(PRIVATE_LOG_PATH_SOURCE "/tmp/OSMPDummySourceLog.log" CACHE FILEPATH "Path to write private log file to")
 endif()
+if(PRIVATE_LOGGING)
+	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH_SOURCE} PRIVATE_LOG_PATH_SOURCE_NATIVE)
+	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH ${PRIVATE_LOG_PATH_SOURCE_NATIVE})
+endif()
 set(VERBOSE_FMI_LOGGING OFF CACHE BOOL "Enable detailed FMI function logging")
 set(DEBUG_BREAKS OFF CACHE BOOL "Enable debugger traps for debug builds of FMU")
 
 string(TIMESTAMP FMUTIMESTAMP UTC)
 string(MD5 FMUGUID modelDescription.in.xml)
 configure_file(modelDescription.in.xml modelDescription.xml @ONLY)
+configure_file(OSMPDummySourceConfig.in.h OSMPDummySourceConfig.h)
 
 find_package(Protobuf 2.6.1 REQUIRED)
 add_library(OSMPDummySource SHARED OSMPDummySource.cpp)
 set_target_properties(OSMPDummySource PROPERTIES PREFIX "")
 target_compile_definitions(OSMPDummySource PRIVATE "FMU_SHARED_OBJECT")
-target_compile_definitions(OSMPDummySource PRIVATE "FMU_GUID=\"${FMUGUID}\"")
 if(LINK_WITH_SHARED_OSI)
 	target_link_libraries(OSMPDummySource open_simulation_interface)
 else()
 	target_link_libraries(OSMPDummySource open_simulation_interface_pic)
 endif()
-if(PRIVATE_LOGGING)
-	file(TO_NATIVE_PATH ${PRIVATE_LOG_PATH_SOURCE} PRIVATE_LOG_PATH_SOURCE_NATIVE)
-	string(REPLACE "\\" "\\\\" PRIVATE_LOG_PATH_SOURCE_ESCAPED ${PRIVATE_LOG_PATH_SOURCE_NATIVE})
-	target_compile_definitions(OSMPDummySource PRIVATE
-		"PRIVATE_LOG_PATH=\"${PRIVATE_LOG_PATH_SOURCE_ESCAPED}\"")
-endif()
-target_compile_definitions(OSMPDummySource PRIVATE
-	$<$<BOOL:${PUBLIC_LOGGING}>:PUBLIC_LOGGING>
-	$<$<BOOL:${VERBOSE_FMI_LOGGING}>:VERBOSE_FMI_LOGGING>
-	$<$<BOOL:${DEBUG_BREAKS}>:DEBUG_BREAKS>)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(WIN32)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -67,5 +62,6 @@ add_custom_command(TARGET OSMPDummySource
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPDummySource.cpp" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
 	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/OSMPDummySource.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/"
+	COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/OSMPDummySourceConfig.h" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources/OSMPDummySourceConfig.h"
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:OSMPDummySource> $<$<PLATFORM_ID:Windows>:$<$<CONFIG:Debug>:$<TARGET_PDB_FILE:OSMPDummySource>>> "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}"
 	COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/buildfmu" ${CMAKE_COMMAND} -E tar "cfv" "../OSMPDummySource.fmu" --format=zip "modelDescription.xml" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/sources" "${CMAKE_CURRENT_BINARY_DIR}/buildfmu/binaries/${FMI_BINARIES_PLATFORM}")

--- a/examples/OSMPDummySource/OSMPDummySource.h
+++ b/examples/OSMPDummySource/OSMPDummySource.h
@@ -8,6 +8,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "OSMPDummySourceConfig.h"
+
 using namespace std;
 
 #ifndef FMU_SHARED_OBJECT

--- a/examples/OSMPDummySource/OSMPDummySourceConfig.in.h
+++ b/examples/OSMPDummySource/OSMPDummySourceConfig.in.h
@@ -1,0 +1,15 @@
+/*
+ * PMSF FMU Framework for FMI 2.0 Co-Simulation FMUs
+ *
+ * (C) 2016 -- 2018 PMSF IT Consulting Pierre R. Mai
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#cmakedefine PUBLIC_LOGGING
+#cmakedefine PRIVATE_LOG_PATH "@PRIVATE_LOG_PATH@"
+#cmakedefine VERBOSE_FMI_LOGGING
+#cmakedefine DEBUG_BREAKS
+#define FMU_GUID "@FMUGUID@"


### PR DESCRIPTION
This changeset makes the compilation configuration durable through
auto-generated configuration include files, which can be embedded in
the FMU sources, thereby making the source code actually compileable.

Note that the C++ examples are still not fully compileable since FMI
does not guarantee C++ compilation capability, and FMI 2.0 cannot
carry the necessary binary/library information needed.

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / Github Actions pass locally with my changes.