### PR TITLE
Introduce ground truth init configuration

### DIFF
--- a/doc/specification.rst
+++ b/doc/specification.rst
@@ -396,8 +396,7 @@ GroundTruth Initialization Parameters
   a parameter named ``OSMPGroundTruthInit``. Its purpose is to provide
   the model with a view of the static environment, in OSI format. 
   What is regarded as static, is specified in 
-  ``osi3::GroundTruthInitConfiguration`` (see the OSI
-   specification documentation for more details). 
+  ``osi3::GroundTruthInitConfiguration`` (see the OSI specification documentation for more details). 
 
 -  ``OSMPGroundTruthInit`` MUST be defined as a notional discrete binary
    input parameter variable, as specified above, with


### PR DESCRIPTION
#### Reference to a related issue in the repository
Architecture group discussions

#### Add a description
Introduced a configuration mechanism for GroundTruthInit with FMU packaging. Goes together with https://github.com/OpenSimulationInterface/open-simulation-interface/pull/407

**Some questions to ask**:
What is this change?
What does it fix?
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?

#### Mention a member
Add @mentions of the person or team responsible for reviewing proposed changes.

#### Check the checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / Github Actions pass locally with my changes.