### PR TITLE
Added TrafficCommandUpdate to OSMP spec

### DIFF
--- a/doc/osi-sensor-model-packaging_spec.adoc
+++ b/doc/osi-sensor-model-packaging_spec.adoc
@@ -41,6 +41,8 @@ include::./spec/ground_truth_init_parameters.adoc[leveloffset=+2]
 
 include::./spec/traffic_command_inputs.adoc[leveloffset=+2]
 
+include::./spec/traffic_command_update_outputs.adoc[leveloffset=+2]
+
 include::./spec/traffic_update_outputs.adoc[leveloffset=+2]
 
 == Examples

--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -20,7 +20,7 @@ Traffic participant models may internally use environmental effect models, senso
 They may also be used to implement surrounding traffic in simplified ways.
 Traffic participant models consume `osi3::SensorView` as input and produce `osi3::TrafficUpdate` as output.
 They may also consume `osi3::TrafficCommand` as input to allow control by a scenario engine or other coordinating function.
-They may also produce `osi3::TrafficCommandUpdate` as output to allow a response to that. 
+They may also produce `osi3::TrafficCommandUpdate` as output to allow status responses to such control messages.
 
 All models may also consume a global `osi3::GroundTruth` parameter during initialization.
 

--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -20,6 +20,7 @@ Traffic participant models may internally use environmental effect models, senso
 They may also be used to implement surrounding traffic in simplified ways.
 Traffic participant models consume `osi3::SensorView` as input and produce `osi3::TrafficUpdate` as output.
 They may also consume `osi3::TrafficCommand` as input to allow control by a scenario engine or other coordinating function.
+They may also produce `osi3::TrafficCommandUpdate` as output to allow a response to that. 
 
 All models may also consume a global `osi3::GroundTruth` parameter during initialization.
 

--- a/doc/spec/traffic_command_update_outputs.adoc
+++ b/doc/spec/traffic_command_update_outputs.adoc
@@ -1,10 +1,10 @@
-= Traffic update outputs
+= Traffic command update outputs
 
 Traffic command update outputs are present in traffic participant models.
 
 **Prefix**
 
-Traffic update outputs shall be named with the following prefix:
+Traffic command update outputs shall be named with the following prefix:
 
 [source,protobuf]
 ----

--- a/doc/spec/traffic_command_update_outputs.adoc
+++ b/doc/spec/traffic_command_update_outputs.adoc
@@ -1,0 +1,22 @@
+= Traffic update outputs
+
+Traffic command update outputs are present in traffic participant models.
+
+**Prefix**
+
+Traffic update outputs shall be named with the following prefix:
+
+[source,protobuf]
+----
+OSMPTrafficCommandUpdateOut
+----
+
+**Rules**
+
+* If only one traffic command update output is configured, the prefix shall only be `OSMPTrafficCommandUpdateOut`.
+* If more than one traffic command update output is configured, the prefix shall be extended by an array index, for example `OSMPTrafficCommandUpdateOut[1]` and `OSMPTrafficCommandUpdateOut[2]`.
+* Array indices shall start at 1 and shall be consecutive.
+* Each traffic command update output shall be defined as a notional discrete binary output variable with a `@causality="output"` and a `@variability="discrete"`.
+* The MIME type of the variable shall specify the `type=TrafficCommandUpdate` as part of the MIME type parameters.
+* Traffic command updates shall be encoded as `osi3::TrafficCommandUpdate`.
+* The guaranteed lifetime of the traffic command update protocol-buffer pointer provided as output by the FMU shall be from the end of the call to `fmi2DoStep` that calculated this buffer until the beginning of the second `fmi2DoStep` call after that.


### PR DESCRIPTION
Extended the OSMP spec to account for the newly added [osi_trafficcommandupdate.proto](https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/osi_trafficcommandupdate.proto).