### PR TITLE
Fix errors in rotation function in OSMPDummySensor

### DIFF
--- a/examples/OSMPDummySensor/OSMPDummySensor.cpp
+++ b/examples/OSMPDummySensor/OSMPDummySensor.cpp
@@ -235,17 +235,12 @@ fmi2Status COSMPDummySensor::doExitInitializationMode()
 
     return fmi2OK;
 }
-
-void transposeRotationMatrix(double matrix_in[3][3], double matrix_trans[3][3]) {
-  for(int i=0; i < 3; i++)
-  {
-    for (int j = 0; j < 3; j++)
-    {
-      matrix_trans[j][i] = matrix_in[i][j];
-    }
-  }
-}
-
+/**
+ * @brief Rotate point with following order of rotation:
+ * 1. roll (around x-axis) 2. pitch (around y-axis) 3. yaw (around z-axis);
+ * 
+ * Positive rotation is counter clockwise (right-hand rule).
+ */
 void rotatePointXYZ(double x, double y, double z,
     double yaw, double pitch, double roll,
     double &rx, double &ry, double &rz)
@@ -258,7 +253,6 @@ void rotatePointXYZ(double x, double y, double z,
     double sin_pitch = sin(pitch);
     double sin_roll = sin(roll);
 
-    /* order of rotation: roll (x-axis), pitch (y-axis), yaw (z-axis) */
     matrix[0][0] = cos_pitch*cos_yaw;                              matrix[0][1] = -cos_pitch*sin_yaw;                             matrix[0][2] = sin_pitch;
     matrix[1][0] = sin_roll*sin_pitch*cos_yaw + cos_roll*sin_yaw;  matrix[1][1] = -sin_roll*sin_pitch*sin_yaw + cos_roll*cos_yaw; matrix[1][2] = -sin_roll*cos_pitch;
     matrix[2][0] = -cos_roll*sin_pitch*cos_yaw + sin_roll*sin_yaw; matrix[2][1] = cos_roll*sin_pitch*sin_yaw + sin_roll*cos_yaw;  matrix[2][2] = cos_roll*cos_pitch;

--- a/examples/OSMPDummySource/OSMPDummySource.cpp
+++ b/examples/OSMPDummySource/OSMPDummySource.cpp
@@ -164,25 +164,6 @@ fmi2Status COSMPDummySource::doExitInitializationMode()
     return fmi2OK;
 }
 
-void rotatePoint(double x, double y, double z,double yaw,double pitch,double roll,double &rx,double &ry,double &rz)
-{
-    double matrix[3][3];
-    double cos_yaw = cos(yaw);
-    double cos_pitch = cos(pitch);
-    double cos_roll = cos(roll);
-    double sin_yaw = sin(yaw);
-    double sin_pitch = sin(pitch);
-    double sin_roll = sin(roll);
-
-    matrix[0][0] = cos_yaw*cos_pitch;  matrix[0][1]=cos_yaw*sin_pitch*sin_roll - sin_yaw*cos_roll; matrix[0][2]=cos_yaw*sin_pitch*cos_roll + sin_yaw*sin_roll;
-    matrix[1][0] = sin_yaw*cos_pitch;  matrix[1][1]=sin_yaw*sin_pitch*sin_roll + cos_yaw*cos_roll; matrix[1][2]=sin_yaw*sin_pitch*cos_roll - cos_yaw*sin_roll;
-    matrix[2][0] = -sin_pitch;         matrix[2][1]=cos_pitch*sin_roll;                            matrix[2][2]=cos_pitch*cos_roll;
-
-    rx = matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z;
-    ry = matrix[1][0] * x + matrix[1][1] * y + matrix[1][2] * z;
-    rz = matrix[2][0] * x + matrix[2][1] * y + matrix[2][2] * z;
-}
-
 fmi2Status COSMPDummySource::doCalc(fmi2Real currentCommunicationPoint, fmi2Real communicationStepSize, fmi2Boolean noSetFMUStatePriorToCurrentPoint)
 {
     DEBUGBREAK();


### PR DESCRIPTION
#### Reference to a related issue in the repository
Fixes #94

#### Add a description
- Added a transpose function for the rotation matrix, as it is a transformation from a global coordinate system to a local system and therefore, the inverse needs to be used
- Changed using the objects orientation to using the ego orientation for calculating the relative position of an object with respect to the ego vehicle.

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works: [Failed unit test](https://github.com/openMSL/sl-1-0-sensor-model-repository-template/actions/runs/4414328802/jobs/7735892106), [Passing unit test](https://github.com/openMSL/sl-1-0-sensor-model-repository-template/actions/runs/4414405272/jobs/7736070483)
- [x] New and existing unit tests / Github Actions pass locally with my changes.