### PR TITLE
Add streaming update consumer model type and interface

### DIFF
--- a/doc/osi-sensor-model-packaging_spec.adoc
+++ b/doc/osi-sensor-model-packaging_spec.adoc
@@ -32,6 +32,8 @@ include::./spec/traffic_command_update_outputs.adoc[leveloffset=+2]
 
 include::./spec/traffic_update_outputs.adoc[leveloffset=+2]
 
+include::./spec/streaming_update_inputs.adoc[leveloffset=+2]
+
 == Examples
 
 include::./setup/build_install_example.adoc[leveloffset=+2]

--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -26,6 +26,11 @@ Traffic participant models consume `osi3::SensorView` as input and produce `osi3
 They may also consume `osi3::TrafficCommand` as input to allow control by a scenario engine or other coordinating function.
 They may also produce `osi3::TrafficCommandUpdate` as output to allow status responses to such control messages.
 
+Streaming update consumer models::
+This model type receives a streaming update input for further processing.
+Examples of this model type can be visualization, evaluation, or logging modules.
+Streaming update consumer models consume `osi3::StreamingUpdate` as input; if they produce any output, it is currently not specified as part of this standard.
+
 All models may also consume a global `osi3::GroundTruth` parameter during initialization.
 
 Complex models may combine various aspects of the above model types.

--- a/doc/spec/streaming_update_inputs.adoc
+++ b/doc/spec/streaming_update_inputs.adoc
@@ -1,0 +1,27 @@
+ifndef::include-only-once[]
+:root-path: ../
+include::{root-path}_config.adoc[]
+endif::[]
+= Streaming update inputs
+
+Streaming update inputs are present in streaming update consumer models.
+They provide incremental updates of environmental simulation state in a way that is suitable for low latency applications.
+
+**Prefix**
+
+Streaming update inputs shall be named with the following prefix:
+
+[source,protobuf]
+----
+OSMPStreamingUpdateIn
+----
+
+**Rules**
+
+* If only one streaming update input is configured, the prefix shall only be `OSMPStreamingUpdateIn`.
+* If more than one streaming update input is configured, the prefix shall be extended by an array index designator, for example `OSMPStreamingUpdateIn[1]` and `OSMPStreamingUpdateIn[2]`.
+* Array indices shall start at 1 and shall be consecutive.
+* Each streaming update input shall be defined as a notional discrete binary input variable with `@causality="input"` and `@variability="discrete"`.
+* The MIME type of the variable shall specify the `type="StreamingUpdate"` as part of the MIME type parameters.
+* Streaming updates shall be encoded as `osi3::StreamingUpdate`.
+* The guaranteed lifetime of the traffic command protocol-buffer pointer provided as input to the FMU shall be from the time of the call to `fmi2SetInteger` that provides those values until the end of the following `fmi2DoStep` call.


### PR DESCRIPTION
This PR adds matchiong definitions for the new streaming update interface introduced in OpenSimulationInterface/open-simulation-interface#718