### PR TITLE
Clarify Traffic Participant Inputs and Outputs

### DIFF
--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -23,8 +23,8 @@ This model type is used to model whole traffic participants, such as vehicles or
 Traffic participant models may internally use environmental effect models, sensor models, or logical models as part of a modeled autonomous vehicle.
 They may also be used to implement surrounding traffic in simplified ways.
 Traffic participant models consume `osi3::SensorView` as input and produce `osi3::TrafficUpdate` as output.
-They may also consume `osi3::TrafficCommand` as input to allow control by a scenario engine or other coordinating function.
-They may also produce `osi3::TrafficCommandUpdate` as output to allow status responses to such control messages.
+They may additionally consume `osi3::TrafficCommand` as input to allow control by a scenario engine or other coordinating function.
+They may additionally produce `osi3::TrafficCommandUpdate` as output to allow status responses to such control messages.
 
 Streaming update consumer models::
 This model type receives a streaming update input for further processing.


### PR DESCRIPTION
#### Add a description
Minor change, exchange 'also' for 'additionally' the clarify, that the mentioned OSI messages can be defined in addition to SensorView and TrafficUpdate. The term 'also' might be misunderstood as 'instead'.

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / Github Actions pass locally with my changes.