### PR TITLE
Add SSP as Packaging in Model Types

### DIFF
--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -4,7 +4,7 @@ include::{root-path}_config.adoc[]
 endif::[]
 = Model types
 
-The current specification supports packaging the following model types as _Functional Mock-up Units_ (FMUs). A model can alternatively be packaged as an OSI-compliant system according to the _System Structure and Parameterization_ (SSP) standard, consisting of multiple FMUs.
+The current specification supports packaging the following model types as _Functional Mock-up Units_ (FMUs).
 
 Environmental effect model::
 This model type can be used to model environmental effects or the physical parts of sensors.
@@ -35,3 +35,5 @@ All models may also consume a global `osi3::GroundTruth` parameter during initia
 
 Complex models may combine various aspects of the above model types.
 Manual intervention is needed to configure and set up these FMUs.
+
+In implementations that support the use of the _System Structure and Parameterization_ (SSP) standard, a model can alternatively be packaged as a system consisting of multiple FMUs, if it presents the same interface at system level as this specification gives for the overall model of the given type.

--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -36,4 +36,4 @@ All models may also consume a global `osi3::GroundTruth` parameter during initia
 Complex models may combine various aspects of the above model types.
 Manual intervention is needed to configure and set up these FMUs.
 
-In implementations that support the use of the _System Structure and Parameterization_ (SSP) standard, a model can alternatively be packaged as a system consisting of multiple FMUs, if it presents the same interface at system level as this specification gives for the overall model of the given type.
+In implementations that support the use of the _System Structure and Parameterization_ (SSP) standard, a model can alternatively be packaged as a system consisting of multiple FMUs, if it presents the same interface at system level as this specification mandates for the overall model of the given type.

--- a/doc/spec/model_types.adoc
+++ b/doc/spec/model_types.adoc
@@ -4,7 +4,7 @@ include::{root-path}_config.adoc[]
 endif::[]
 = Model types
 
-The current specification supports packaging the following model types as _Functional Mock-up Units_ (FMUs):
+The current specification supports packaging the following model types as _Functional Mock-up Units_ (FMUs). A model can alternatively be packaged as an OSI-compliant system according to the _System Structure and Parameterization_ (SSP) standard, consisting of multiple FMUs.
 
 Environmental effect model::
 This model type can be used to model environmental effects or the physical parts of sensors.


### PR DESCRIPTION
#### Reference to a related issue in the repository
#102 

#### Add a description
Since models, e.g. traffic participants, can consist of multiple connected FMUs, SSP was added next to FMU as a possible packaging for OSMP models.

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / Github Actions pass locally with my changes.