### PR TITLE
Change 'static' to 'not changing' in the specification of GroundTruthInit

### DIFF
--- a/doc/spec/ground_truth_init_parameters.adoc
+++ b/doc/spec/ground_truth_init_parameters.adoc
@@ -5,17 +5,17 @@ endif::[]
 = Ground truth initialization parameters
 
 All models can optionally consume `osi3::GroundTruth` via an initialization parameter called `OSMPGroundTruthInit`.
-Its purpose is to provide the model with a view of the static environment, for example the map, in OSI format.
+Its purpose is to provide the model with information that is constant throughout the simulation, for example the map in OSI format or the model_reference of a MovingObject.
 
-`OSMPGroundTruthInit` contains all static data encountered by the model during a simulation run, for example, roads.
-All data provided in this message can be assumed by the receiver to be static during the simulation run.
+`OSMPGroundTruthInit` contains all constant data encountered by the model during a simulation run, for example, roads.
+All data provided in this message can be assumed by the receiver to be constant during the simulation run.
 
 If the model is instantiated multiple times, all instantiations should receive the exact same content.
-This allows a model to do expensive map calculations only once during initialization, and to share the calculated data between multiple instantiations.
+This allows a model to do expensive map calculations or loading 3D assets only once during initialization, and to share the calculated data between multiple instantiations.
 
 **Prefix**
 
-Ground truth initialization paramters shall be named with the following prefix:
+Ground truth initialization parameters shall be named with the following prefix:
 
 [source,protobuf]
 ----
@@ -28,7 +28,7 @@ OSMPGroundTruthInit
 * `OSMPGroundTruthInit` shall be defined as a notional discrete binary input parameter variable, with `@causality="parameter"`, `@variability="fixed"` and `@initial="exact"`.
 * The MIME type of the variable shall specify the `type=GroundTruth` as part of the MIME type parameters.
 * `OSMPGroundTruthInit` shall be encoded as `osi3::GroundTruth`.
-* `OSMPGroundTruthInit` shall contain all static data encountered by the model during a simulation run.
+* `OSMPGroundTruthInit` shall contain all constant data encountered by the model during a simulation run.
 * The IDs of objects in `OSMPGroundTruthInit` shall be identical to the IDs of the same objects contained in later `OSMPSensorViewIn` or other input data.
 * If the model is instantiated multiple times, then all instantiations should receive the exact same content stored in the `OSMPGroundTruthInit` parameter.
 * The guaranteed lifetime of the ground-truth protocol-buffer pointer provided as input to the FMU shall be from the time of the call to `fmi2SetInteger` that provides those values until the end of the following `fmi2ExitInitializationMode` call.

--- a/doc/spec/ground_truth_init_parameters.adoc
+++ b/doc/spec/ground_truth_init_parameters.adoc
@@ -7,8 +7,8 @@ endif::[]
 All models can optionally consume `osi3::GroundTruth` via an initialization parameter called `OSMPGroundTruthInit`.
 Its purpose is to provide the model with information that does not change throughout the simulation, for example the map in OSI format or the model_reference of a MovingObject.
 
-`OSMPGroundTruthInit` contains all constant data encountered by the model during a simulation run, for example, roads.
-All data provided in this message can be assumed by the receiver to be constant during the simulation run.
+`OSMPGroundTruthInit` contains all data encountered by the model that does not change during a simulation run, for example, roads.
+All data provided in this message can be assumed by the receiver to not change during the simulation run.
 
 If the model is instantiated multiple times, all instantiations should receive the exact same content.
 This allows a model to do expensive map calculations or loading 3D assets only once during initialization, and to share the calculated data between multiple instantiations.
@@ -28,7 +28,7 @@ OSMPGroundTruthInit
 * `OSMPGroundTruthInit` shall be defined as a notional discrete binary input parameter variable, with `@causality="parameter"`, `@variability="fixed"` and `@initial="exact"`.
 * The MIME type of the variable shall specify the `type=GroundTruth` as part of the MIME type parameters.
 * `OSMPGroundTruthInit` shall be encoded as `osi3::GroundTruth`.
-* `OSMPGroundTruthInit` shall contain all constant data encountered by the model during a simulation run.
+* `OSMPGroundTruthInit` shall contain all data encountered by the model that does not change during a simulation run.
 * The IDs of objects in `OSMPGroundTruthInit` shall be identical to the IDs of the same objects contained in later `OSMPSensorViewIn` or other input data.
 * If the model is instantiated multiple times, then all instantiations should receive the exact same content stored in the `OSMPGroundTruthInit` parameter.
 * The guaranteed lifetime of the ground-truth protocol-buffer pointer provided as input to the FMU shall be from the time of the call to `fmi2SetInteger` that provides those values until the end of the following `fmi2ExitInitializationMode` call.

--- a/doc/spec/ground_truth_init_parameters.adoc
+++ b/doc/spec/ground_truth_init_parameters.adoc
@@ -5,10 +5,11 @@ endif::[]
 = Ground truth initialization parameters
 
 All models can optionally consume `osi3::GroundTruth` via an initialization parameter called `OSMPGroundTruthInit`.
-Its purpose is to provide the model with information that does not change throughout the simulation, for example the map in OSI format or the model_reference of a MovingObject.
+Its purpose is to provide the model with information in OSI format that does not change throughout the simulation, i.e. is considered static.
+This can encompass, for example, the road network or referenced 3D models.
 
-`OSMPGroundTruthInit` contains all data encountered by the model that does not change during a simulation run, for example, roads.
-All data provided in this message can be assumed by the receiver to not change during the simulation run.
+`OSMPGroundTruthInit` contains only data encountered by the model that does not change during a simulation run.
+All data provided in this message can be assumed by the receiver to be static during the simulation run.
 
 If the model is instantiated multiple times, all instantiations should receive the exact same content.
 This allows a model to do expensive map calculations or loading 3D assets only once during initialization, and to share the calculated data between multiple instantiations.
@@ -28,7 +29,7 @@ OSMPGroundTruthInit
 * `OSMPGroundTruthInit` shall be defined as a notional discrete binary input parameter variable, with `@causality="parameter"`, `@variability="fixed"` and `@initial="exact"`.
 * The MIME type of the variable shall specify the `type=GroundTruth` as part of the MIME type parameters.
 * `OSMPGroundTruthInit` shall be encoded as `osi3::GroundTruth`.
-* `OSMPGroundTruthInit` shall contain all data encountered by the model that does not change during a simulation run.
+* `OSMPGroundTruthInit` shall contain only data encountered by the model that does not change during a simulation run.
 * The IDs of objects in `OSMPGroundTruthInit` shall be identical to the IDs of the same objects contained in later `OSMPSensorViewIn` or other input data.
 * If the model is instantiated multiple times, then all instantiations should receive the exact same content stored in the `OSMPGroundTruthInit` parameter.
 * The guaranteed lifetime of the ground-truth protocol-buffer pointer provided as input to the FMU shall be from the time of the call to `fmi2SetInteger` that provides those values until the end of the following `fmi2ExitInitializationMode` call.

--- a/doc/spec/ground_truth_init_parameters.adoc
+++ b/doc/spec/ground_truth_init_parameters.adoc
@@ -5,7 +5,7 @@ endif::[]
 = Ground truth initialization parameters
 
 All models can optionally consume `osi3::GroundTruth` via an initialization parameter called `OSMPGroundTruthInit`.
-Its purpose is to provide the model with information that is constant throughout the simulation, for example the map in OSI format or the model_reference of a MovingObject.
+Its purpose is to provide the model with information that does not change throughout the simulation, for example the map in OSI format or the model_reference of a MovingObject.
 
 `OSMPGroundTruthInit` contains all constant data encountered by the model during a simulation run, for example, roads.
 All data provided in this message can be assumed by the receiver to be constant during the simulation run.


### PR DESCRIPTION
#### Reference to a related issue in the repository
#107 

#### Add a description
Extend GroundTruthInit specification to also cover constant properties of other GroundTruth data, such as the model_reference in MovingObject.

#### Mention a member
@pmai @LudwigFriedmann 

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / Github Actions pass locally with my changes.