### PR TITLE
Clarify mime type of FMI 3.0 binary variables

### DIFF
--- a/doc/spec/binary_variables.adoc
+++ b/doc/spec/binary_variables.adoc
@@ -95,6 +95,7 @@ The actual binary variable shall contain an annotation of the following form in 
 It is an error if there is not exactly one variable for the same name.
 
 The MIME type given in `@mime-type` shall be a valid MIME type specification.
+It shall be identical to the MIME type specification given in the `@mimeType` attribute of the binary variable element.
 
 In the case of OSI-specified data, the MIME type shall have the following form to indicate that the binary content is conformant to the given OSI version and contains a message of the given type:
 


### PR DESCRIPTION
Based on review feedback, clarify that FMI 3.0 binary variable `mimeType` attribute and annotation `mime-type` attribute must match.