### PR TITLE
Remove using namespace std from header files

### DIFF
--- a/examples/OSMPDummySensor/OSMPDummySensor.h
+++ b/examples/OSMPDummySensor/OSMPDummySensor.h
@@ -10,8 +10,6 @@
 
 #include "OSMPDummySensorConfig.h"
 
-using namespace std;
-
 #ifndef FMU_SHARED_OBJECT
 #define FMI2_FUNCTION_PREFIX OSMPDummySensor_
 #endif
@@ -122,7 +120,7 @@ protected:
 protected:
     /* Private File-based Logging just for Debugging */
 #ifdef PRIVATE_LOG_PATH
-    static ofstream private_log_file;
+    static std::ofstream private_log_file;
 #endif
 
     static void fmi_verbose_log_global(const char* format, ...) {
@@ -157,9 +155,9 @@ protected:
 #endif
 #ifdef PRIVATE_LOG_PATH
         if (!private_log_file.is_open())
-            private_log_file.open(PRIVATE_LOG_PATH, ios::out | ios::app);
+            private_log_file.open(PRIVATE_LOG_PATH, std::ios::out | std::ios::app);
         if (private_log_file.is_open()) {
-            private_log_file << "OSMPDummySensor" << "::" << instanceName << "<" << ((void*)this) << ">:" << category << ": " << buffer << endl;
+            private_log_file << "OSMPDummySensor" << "::" << instanceName << "<" << ((void*)this) << ">:" << category << ": " << buffer << std::endl;
             private_log_file.flush();
         }
 #endif
@@ -191,23 +189,23 @@ protected:
 
 protected:
     /* Members */
-    string instanceName;
+    std::string instanceName;
     fmi2Type fmuType;
-    string fmuGUID;
-    string fmuResourceLocation;
+    std::string fmuGUID;
+    std::string fmuResourceLocation;
     bool visible;
     bool loggingOn;
-    set<string> loggingCategories;
+    std::set<std::string> loggingCategories;
     fmi2CallbackFunctions functions;
     fmi2Boolean boolean_vars[FMI_BOOLEAN_VARS];
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
-    string string_vars[FMI_STRING_VARS];
+    std::string string_vars[FMI_STRING_VARS];
     bool simulation_started;
-    string* currentOutputBuffer;
-    string* lastOutputBuffer;
-    string* currentConfigRequestBuffer;
-    string* lastConfigRequestBuffer;
+    std::string* currentOutputBuffer;
+    std::string* lastOutputBuffer;
+    std::string* currentConfigRequestBuffer;
+    std::string* lastConfigRequestBuffer;
 
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }

--- a/examples/OSMPDummySource/OSMPDummySource.h
+++ b/examples/OSMPDummySource/OSMPDummySource.h
@@ -10,8 +10,6 @@
 
 #include "OSMPDummySourceConfig.h"
 
-using namespace std;
-
 #ifndef FMU_SHARED_OBJECT
 #define FMI2_FUNCTION_PREFIX OSMPDummySource_
 #endif
@@ -111,7 +109,7 @@ protected:
 protected:
     /* Private File-based Logging just for Debugging */
 #ifdef PRIVATE_LOG_PATH
-    static ofstream private_log_file;
+    static std::ofstream private_log_file;
 #endif
 
     static void fmi_verbose_log_global(const char* format, ...) {
@@ -146,9 +144,9 @@ protected:
 #endif
 #ifdef PRIVATE_LOG_PATH
         if (!private_log_file.is_open())
-            private_log_file.open(PRIVATE_LOG_PATH, ios::out | ios::app);
+            private_log_file.open(PRIVATE_LOG_PATH, std::ios::out | std::ios::app);
         if (private_log_file.is_open()) {
-            private_log_file << "OSMPDummySource" << "::" << instanceName << "<" << ((void*)this) << ">:" << category << ": " << buffer << endl;
+            private_log_file << "OSMPDummySource" << "::" << instanceName << "<" << ((void*)this) << ">:" << category << ": " << buffer << std::endl;
             private_log_file.flush();
         }
 #endif
@@ -180,20 +178,20 @@ protected:
 
 protected:
     /* Members */
-    string instanceName;
+    std::string instanceName;
     fmi2Type fmuType;
-    string fmuGUID;
-    string fmuResourceLocation;
+    std::string fmuGUID;
+    std::string fmuResourceLocation;
     bool visible;
     bool loggingOn;
-    set<string> loggingCategories;
+    std::set<std::string> loggingCategories;
     fmi2CallbackFunctions functions;
     fmi2Boolean boolean_vars[FMI_BOOLEAN_VARS];
     fmi2Integer integer_vars[FMI_INTEGER_VARS];
     fmi2Real real_vars[FMI_REAL_VARS];
-    string string_vars[FMI_STRING_VARS];
-    string* currentBuffer;
-    string* lastBuffer;
+    std::string string_vars[FMI_STRING_VARS];
+    std::string* currentBuffer;
+    std::string* lastBuffer;
 
     /* Simple Accessors */
     fmi2Boolean fmi_valid() { return boolean_vars[FMI_BOOLEAN_VALID_IDX]; }


### PR DESCRIPTION
#### Reference to a related issue in the repository
Fixes https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/issues/114
#### Add a description
Remove `using namespace std` and add full qualifier where needed

#### Check the checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/OpenSimulationInterface/osi-documentation) for osi-sensor-model-packaging.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / Github Actions pass locally with my changes.